### PR TITLE
Add SVG Overview GH Page and Generation Script

### DIFF
--- a/generate_index.py
+++ b/generate_index.py
@@ -1,0 +1,135 @@
+import os
+
+def get_wiki_link(filename):
+    # Mapping for special cases
+    mapping = {
+        'tnt_side': 'TNT',
+        'grass_block_top': 'Grass_Block',
+        'crafting_table_top': 'Crafting_Table',
+        'oak_log': 'Oak_Log',
+        'oak_planks': 'Oak_Planks',
+        'diamond_pickaxe': 'Diamond_Pickaxe',
+        'iron_sword': 'Iron_Sword',
+        'gold_ingot': 'Gold_Ingot',
+        'iron_ingot': 'Iron_Ingot',
+        'netherite_ingot': 'Netherite_Ingot',
+        'water_bucket': 'Water_Bucket'
+    }
+
+    name = os.path.splitext(filename)[0]
+    if name in mapping:
+        wiki_name = mapping[name]
+    else:
+        wiki_name = name.capitalize()
+
+    return f"https://minecraft.fandom.com/wiki/{wiki_name}"
+
+def main():
+    svg_dir = 'svgs'
+    svg_files = sorted([f for f in os.listdir(svg_dir) if f.endswith('.svg')])
+
+    html_content = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minecraft Textures SVG Overview</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            background-color: #f0f0f0;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        h1 {
+            color: #333;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 20px;
+            width: 100%;
+            max-width: 1200px;
+        }
+        .card {
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            padding: 15px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            transition: transform 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+        }
+        .card img {
+            width: 128px;
+            height: 128px;
+            image-rendering: pixelated;
+            margin-bottom: 10px;
+        }
+        .card a {
+            text-decoration: none;
+            color: #007bff;
+            font-weight: bold;
+        }
+        .card a:hover {
+            text-decoration: underline;
+        }
+        .card .name {
+            margin-bottom: 10px;
+            font-size: 1.1em;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+    <h1>Minecraft Textures SVG Overview</h1>
+    <div class="grid">
+"""
+
+    for svg_file in svg_files:
+        base_name = os.path.splitext(svg_file)[0]
+        # Custom display names
+        display_names = {
+            'tnt_side': 'TNT',
+            'grass_block_top': 'Grass Block',
+            'crafting_table_top': 'Crafting Table',
+            'oak_log': 'Oak Log',
+            'oak_planks': 'Oak Planks',
+            'diamond_pickaxe': 'Diamond Pickaxe',
+            'iron_sword': 'Iron Sword',
+            'gold_ingot': 'Gold Ingot',
+            'iron_ingot': 'Iron Ingot',
+            'netherite_ingot': 'Netherite Ingot',
+            'water_bucket': 'Water Bucket'
+        }
+        name = display_names.get(base_name, base_name.replace('_', ' ').title())
+        wiki_link = get_wiki_link(svg_file)
+        html_content += f"""
+        <div class="card">
+            <img src="svgs/{svg_file}" alt="{name}">
+            <div class="name">{name}</div>
+            <a href="{wiki_link}" target="_blank">View on Fandom Wiki</a>
+        </div>
+"""
+
+    html_content += """
+    </div>
+</body>
+</html>
+"""
+
+    with open('index.html', 'w') as f:
+        f.write(html_content)
+    print("Generated index.html")
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,189 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minecraft Textures SVG Overview</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            background-color: #f0f0f0;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        h1 {
+            color: #333;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 20px;
+            width: 100%;
+            max-width: 1200px;
+        }
+        .card {
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            padding: 15px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            transition: transform 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+        }
+        .card img {
+            width: 128px;
+            height: 128px;
+            image-rendering: pixelated;
+            margin-bottom: 10px;
+        }
+        .card a {
+            text-decoration: none;
+            color: #007bff;
+            font-weight: bold;
+        }
+        .card a:hover {
+            text-decoration: underline;
+        }
+        .card .name {
+            margin-bottom: 10px;
+            font-size: 1.1em;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+    <h1>Minecraft Textures SVG Overview</h1>
+    <div class="grid">
+
+        <div class="card">
+            <img src="svgs/apple.svg" alt="Apple">
+            <div class="name">Apple</div>
+            <a href="https://minecraft.fandom.com/wiki/Apple" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/bread.svg" alt="Bread">
+            <div class="name">Bread</div>
+            <a href="https://minecraft.fandom.com/wiki/Bread" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/chest.svg" alt="Chest">
+            <div class="name">Chest</div>
+            <a href="https://minecraft.fandom.com/wiki/Chest" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/cobblestone.svg" alt="Cobblestone">
+            <div class="name">Cobblestone</div>
+            <a href="https://minecraft.fandom.com/wiki/Cobblestone" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/crafting_table_top.svg" alt="Crafting Table">
+            <div class="name">Crafting Table</div>
+            <a href="https://minecraft.fandom.com/wiki/Crafting_Table" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/diamond.svg" alt="Diamond">
+            <div class="name">Diamond</div>
+            <a href="https://minecraft.fandom.com/wiki/Diamond" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/diamond_pickaxe.svg" alt="Diamond Pickaxe">
+            <div class="name">Diamond Pickaxe</div>
+            <a href="https://minecraft.fandom.com/wiki/Diamond_Pickaxe" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/dirt.svg" alt="Dirt">
+            <div class="name">Dirt</div>
+            <a href="https://minecraft.fandom.com/wiki/Dirt" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/glass.svg" alt="Glass">
+            <div class="name">Glass</div>
+            <a href="https://minecraft.fandom.com/wiki/Glass" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/gold_ingot.svg" alt="Gold Ingot">
+            <div class="name">Gold Ingot</div>
+            <a href="https://minecraft.fandom.com/wiki/Gold_Ingot" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/grass_block_top.svg" alt="Grass Block">
+            <div class="name">Grass Block</div>
+            <a href="https://minecraft.fandom.com/wiki/Grass_Block" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/iron_ingot.svg" alt="Iron Ingot">
+            <div class="name">Iron Ingot</div>
+            <a href="https://minecraft.fandom.com/wiki/Iron_Ingot" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/iron_sword.svg" alt="Iron Sword">
+            <div class="name">Iron Sword</div>
+            <a href="https://minecraft.fandom.com/wiki/Iron_Sword" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/netherite_ingot.svg" alt="Netherite Ingot">
+            <div class="name">Netherite Ingot</div>
+            <a href="https://minecraft.fandom.com/wiki/Netherite_Ingot" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/oak_log.svg" alt="Oak Log">
+            <div class="name">Oak Log</div>
+            <a href="https://minecraft.fandom.com/wiki/Oak_Log" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/oak_planks.svg" alt="Oak Planks">
+            <div class="name">Oak Planks</div>
+            <a href="https://minecraft.fandom.com/wiki/Oak_Planks" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/stone.svg" alt="Stone">
+            <div class="name">Stone</div>
+            <a href="https://minecraft.fandom.com/wiki/Stone" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/tnt_side.svg" alt="TNT">
+            <div class="name">TNT</div>
+            <a href="https://minecraft.fandom.com/wiki/TNT" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/torch.svg" alt="Torch">
+            <div class="name">Torch</div>
+            <a href="https://minecraft.fandom.com/wiki/Torch" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/water_bucket.svg" alt="Water Bucket">
+            <div class="name">Water Bucket</div>
+            <a href="https://minecraft.fandom.com/wiki/Water_Bucket" target="_blank">View on Fandom Wiki</a>
+        </div>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This change adds a GitHub Pages overview page that displays all Minecraft SVG textures in a grid layout. Each texture is displayed at a reasonable size and includes a direct link to its corresponding page on the Minecraft Fandom Wiki. A Python script `generate_index.py` is included to allow for easy updates as more SVGs are added to the repository.

Fixes #8

---
*PR created automatically by Jules for task [16364357273452012808](https://jules.google.com/task/16364357273452012808) started by @chatelao*