### PR TITLE
Add GitHub Pages link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains 19 of the most popular and iconic Minecraft textures, along with their 32x32 color maps in JSON format.
 
+You can view an interactive preview of these textures on the [GitHub Pages site](https://chatelao.github.io/minecraft-led-panel-and-cube/).
+
 ## Texture List
 
 | Texture Name | Preview | Color Map (JSON) |


### PR DESCRIPTION
Added a link to the interactive GitHub Pages site in the README.md introductory section. Verified the link format and ensured no regressions in other files.

Fixes #13

---
*PR created automatically by Jules for task [11151914362333805369](https://jules.google.com/task/11151914362333805369) started by @chatelao*