### PR TITLE
Fix GitHub Pages wiki links and broken assets

### DIFF
--- a/generate_index.py
+++ b/generate_index.py
@@ -1,6 +1,6 @@
 import os
 
-def get_wiki_link(filename):
+def get_wiki_link(base_name):
     # Mapping for special cases
     mapping = {
         'tnt_side': 'TNT',
@@ -16,13 +16,12 @@ def get_wiki_link(filename):
         'water_bucket': 'Water_Bucket'
     }
 
-    name = os.path.splitext(filename)[0]
-    if name in mapping:
-        wiki_name = mapping[name]
+    if base_name in mapping:
+        wiki_name = mapping[base_name]
     else:
-        wiki_name = name.capitalize()
+        wiki_name = base_name.replace('_', ' ').title().replace(' ', '_')
 
-    return f"https://minecraft.fandom.com/wiki/{wiki_name}"
+    return f"https://minecraft.wiki/w/{wiki_name}"
 
 def main():
     svg_dir = 'svgs'
@@ -112,12 +111,12 @@ def main():
             'water_bucket': 'Water Bucket'
         }
         name = display_names.get(base_name, base_name.replace('_', ' ').title())
-        wiki_link = get_wiki_link(svg_file)
+        wiki_link = get_wiki_link(base_name)
         html_content += f"""
         <div class="card">
             <img src="svgs/{svg_file}" alt="{name}">
             <div class="name">{name}</div>
-            <a href="{wiki_link}" target="_blank">View on Fandom Wiki</a>
+            <a href="{wiki_link}" target="_blank">View on Minecraft Wiki</a>
         </div>
 """
 

--- a/index.html
+++ b/index.html
@@ -67,121 +67,115 @@
         <div class="card">
             <img src="svgs/apple.svg" alt="Apple">
             <div class="name">Apple</div>
-            <a href="https://minecraft.fandom.com/wiki/Apple" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Apple" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/bread.svg" alt="Bread">
             <div class="name">Bread</div>
-            <a href="https://minecraft.fandom.com/wiki/Bread" target="_blank">View on Fandom Wiki</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/chest.svg" alt="Chest">
-            <div class="name">Chest</div>
-            <a href="https://minecraft.fandom.com/wiki/Chest" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Bread" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/cobblestone.svg" alt="Cobblestone">
             <div class="name">Cobblestone</div>
-            <a href="https://minecraft.fandom.com/wiki/Cobblestone" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Cobblestone" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/crafting_table_top.svg" alt="Crafting Table">
             <div class="name">Crafting Table</div>
-            <a href="https://minecraft.fandom.com/wiki/Crafting_Table" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Crafting_Table" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/diamond.svg" alt="Diamond">
             <div class="name">Diamond</div>
-            <a href="https://minecraft.fandom.com/wiki/Diamond" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Diamond" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/diamond_pickaxe.svg" alt="Diamond Pickaxe">
             <div class="name">Diamond Pickaxe</div>
-            <a href="https://minecraft.fandom.com/wiki/Diamond_Pickaxe" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Diamond_Pickaxe" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/dirt.svg" alt="Dirt">
             <div class="name">Dirt</div>
-            <a href="https://minecraft.fandom.com/wiki/Dirt" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Dirt" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/glass.svg" alt="Glass">
             <div class="name">Glass</div>
-            <a href="https://minecraft.fandom.com/wiki/Glass" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Glass" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/gold_ingot.svg" alt="Gold Ingot">
             <div class="name">Gold Ingot</div>
-            <a href="https://minecraft.fandom.com/wiki/Gold_Ingot" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Gold_Ingot" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/grass_block_top.svg" alt="Grass Block">
             <div class="name">Grass Block</div>
-            <a href="https://minecraft.fandom.com/wiki/Grass_Block" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Grass_Block" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/iron_ingot.svg" alt="Iron Ingot">
             <div class="name">Iron Ingot</div>
-            <a href="https://minecraft.fandom.com/wiki/Iron_Ingot" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Iron_Ingot" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/iron_sword.svg" alt="Iron Sword">
             <div class="name">Iron Sword</div>
-            <a href="https://minecraft.fandom.com/wiki/Iron_Sword" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Iron_Sword" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/netherite_ingot.svg" alt="Netherite Ingot">
             <div class="name">Netherite Ingot</div>
-            <a href="https://minecraft.fandom.com/wiki/Netherite_Ingot" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Netherite_Ingot" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/oak_log.svg" alt="Oak Log">
             <div class="name">Oak Log</div>
-            <a href="https://minecraft.fandom.com/wiki/Oak_Log" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Oak_Log" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/oak_planks.svg" alt="Oak Planks">
             <div class="name">Oak Planks</div>
-            <a href="https://minecraft.fandom.com/wiki/Oak_Planks" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Oak_Planks" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/stone.svg" alt="Stone">
             <div class="name">Stone</div>
-            <a href="https://minecraft.fandom.com/wiki/Stone" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Stone" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/tnt_side.svg" alt="TNT">
             <div class="name">TNT</div>
-            <a href="https://minecraft.fandom.com/wiki/TNT" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/TNT" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/torch.svg" alt="Torch">
             <div class="name">Torch</div>
-            <a href="https://minecraft.fandom.com/wiki/Torch" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Torch" target="_blank">View on Minecraft Wiki</a>
         </div>
 
         <div class="card">
             <img src="svgs/water_bucket.svg" alt="Water Bucket">
             <div class="name">Water Bucket</div>
-            <a href="https://minecraft.fandom.com/wiki/Water_Bucket" target="_blank">View on Fandom Wiki</a>
+            <a href="https://minecraft.wiki/w/Water_Bucket" target="_blank">View on Minecraft Wiki</a>
         </div>
 
     </div>


### PR DESCRIPTION
Fixed the GitHub Pages site by updating links to the official Minecraft Wiki and removing a broken entry for a non-existent "Chest" texture. Regenerated `index.html` using an updated `generate_index.py` script to ensure all displayed textures have valid previews and links.

Fixes #21

---
*PR created automatically by Jules for task [15613905068544645741](https://jules.google.com/task/15613905068544645741) started by @chatelao*