### PR TITLE
Add "Paint by Numbers" PDF generation and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
 # Popular Minecraft Textures
 
-This repository contains 19 of the most popular and iconic Minecraft textures, along with their 32x32 color maps in JSON format.
+This repository contains 19 of the most popular and iconic Minecraft textures, along with their 32x32 color maps in JSON format and "Paint by Numbers" PDFs.
 
 You can view an interactive preview of these textures on the [GitHub Pages site](https://chatelao.github.io/minecraft-led-panel-and-cube/).
 
 ## Texture List
 
-| Texture Name | Preview | Color Map (JSON) |
-|--------------|---------|------------------|
-| TNT | ![TNT](svgs/tnt_side.svg) | [tnt_side.json](color_maps/tnt_side.json) |
-| Oak Log | ![Oak Log](svgs/oak_log.svg) | [oak_log.json](color_maps/oak_log.json) |
-| Stone | ![Stone](svgs/stone.svg) | [stone.json](color_maps/stone.json) |
-| Diamond | ![Diamond](svgs/diamond.svg) | [diamond.json](color_maps/diamond.json) |
-| Netherite Ingot | ![Netherite Ingot](svgs/netherite_ingot.svg) | [netherite_ingot.json](color_maps/netherite_ingot.json) |
-| Grass Block | ![Grass Block](svgs/grass_block_top.svg) | [grass_block_top.json](color_maps/grass_block_top.json) |
-| Dirt | ![Dirt](svgs/dirt.svg) | [dirt.json](color_maps/dirt.json) |
-| Cobblestone | ![Cobblestone](svgs/cobblestone.svg) | [cobblestone.json](color_maps/cobblestone.json) |
-| Oak Planks | ![Oak Planks](svgs/oak_planks.svg) | [oak_planks.json](color_maps/oak_planks.json) |
-| Crafting Table | ![Crafting Table](svgs/crafting_table_top.svg) | [crafting_table_top.json](color_maps/crafting_table_top.json) |
-| Iron Ingot | ![Iron Ingot](svgs/iron_ingot.svg) | [iron_ingot.json](color_maps/iron_ingot.json) |
-| Gold Ingot | ![Gold Ingot](svgs/gold_ingot.svg) | [gold_ingot.json](color_maps/gold_ingot.json) |
-| Apple | ![Apple](svgs/apple.svg) | [apple.json](color_maps/apple.json) |
-| Bread | ![Bread](svgs/bread.svg) | [bread.json](color_maps/bread.json) |
-| Iron Sword | ![Iron Sword](svgs/iron_sword.svg) | [iron_sword.json](color_maps/iron_sword.json) |
-| Diamond Pickaxe | ![Diamond Pickaxe](svgs/diamond_pickaxe.svg) | [diamond_pickaxe.json](color_maps/diamond_pickaxe.json) |
-| Torch | ![Torch](svgs/torch.svg) | [torch.json](color_maps/torch.json) |
-| Water Bucket | ![Water Bucket](svgs/water_bucket.svg) | [water_bucket.json](color_maps/water_bucket.json) |
-| Glass | ![Glass](svgs/glass.svg) | [glass.json](color_maps/glass.json) |
+| Texture Name | Preview | Color Map (JSON) | Paint by Numbers |
+|--------------|---------|------------------|-------------------|
+| TNT | ![TNT](svgs/tnt_side.svg) | [tnt_side.json](color_maps/tnt_side.json) | [tnt_side.pdf](paint_by_numbers/tnt_side.pdf) |
+| Oak Log | ![Oak Log](svgs/oak_log.svg) | [oak_log.json](color_maps/oak_log.json) | [oak_log.pdf](paint_by_numbers/oak_log.pdf) |
+| Stone | ![Stone](svgs/stone.svg) | [stone.json](color_maps/stone.json) | [stone.pdf](paint_by_numbers/stone.pdf) |
+| Diamond | ![Diamond](svgs/diamond.svg) | [diamond.json](color_maps/diamond.json) | [diamond.pdf](paint_by_numbers/diamond.pdf) |
+| Netherite Ingot | ![Netherite Ingot](svgs/netherite_ingot.svg) | [netherite_ingot.json](color_maps/netherite_ingot.json) | [netherite_ingot.pdf](paint_by_numbers/netherite_ingot.pdf) |
+| Grass Block | ![Grass Block](svgs/grass_block_top.svg) | [grass_block_top.json](color_maps/grass_block_top.json) | [grass_block_top.pdf](paint_by_numbers/grass_block_top.pdf) |
+| Dirt | ![Dirt](svgs/dirt.svg) | [dirt.json](color_maps/dirt.json) | [dirt.pdf](paint_by_numbers/dirt.pdf) |
+| Cobblestone | ![Cobblestone](svgs/cobblestone.svg) | [cobblestone.json](color_maps/cobblestone.json) | [cobblestone.pdf](paint_by_numbers/cobblestone.pdf) |
+| Oak Planks | ![Oak Planks](svgs/oak_planks.svg) | [oak_planks.json](color_maps/oak_planks.json) | [oak_planks.pdf](paint_by_numbers/oak_planks.pdf) |
+| Crafting Table | ![Crafting Table](svgs/crafting_table_top.svg) | [crafting_table_top.json](color_maps/crafting_table_top.json) | [crafting_table_top.pdf](paint_by_numbers/crafting_table_top.pdf) |
+| Iron Ingot | ![Iron Ingot](svgs/iron_ingot.svg) | [iron_ingot.json](color_maps/iron_ingot.json) | [iron_ingot.pdf](paint_by_numbers/iron_ingot.pdf) |
+| Gold Ingot | ![Gold Ingot](svgs/gold_ingot.svg) | [gold_ingot.json](color_maps/gold_ingot.json) | [gold_ingot.pdf](paint_by_numbers/gold_ingot.pdf) |
+| Apple | ![Apple](svgs/apple.svg) | [apple.json](color_maps/apple.json) | [apple.pdf](paint_by_numbers/apple.pdf) |
+| Bread | ![Bread](svgs/bread.svg) | [bread.json](color_maps/bread.json) | [bread.pdf](paint_by_numbers/bread.pdf) |
+| Iron Sword | ![Iron Sword](svgs/iron_sword.svg) | [iron_sword.json](color_maps/iron_sword.json) | [iron_sword.pdf](paint_by_numbers/iron_sword.pdf) |
+| Diamond Pickaxe | ![Diamond Pickaxe](svgs/diamond_pickaxe.svg) | [diamond_pickaxe.json](color_maps/diamond_pickaxe.json) | [diamond_pickaxe.pdf](paint_by_numbers/diamond_pickaxe.pdf) |
+| Torch | ![Torch](svgs/torch.svg) | [torch.json](color_maps/torch.json) | [torch.pdf](paint_by_numbers/torch.pdf) |
+| Water Bucket | ![Water Bucket](svgs/water_bucket.svg) | [water_bucket.json](color_maps/water_bucket.json) | [water_bucket.pdf](paint_by_numbers/water_bucket.pdf) |
+| Glass | ![Glass](svgs/glass.svg) | [glass.json](color_maps/glass.json) | [glass.pdf](paint_by_numbers/glass.pdf) |
 
 ## JSON Color Map Format
 

--- a/generate_index.py
+++ b/generate_index.py
@@ -78,6 +78,7 @@ def main():
             text-decoration: none;
             color: #007bff;
             font-weight: bold;
+            margin: 5px 0;
         }
         .card a:hover {
             text-decoration: underline;
@@ -117,6 +118,7 @@ def main():
             <img src="svgs/{svg_file}" alt="{name}">
             <div class="name">{name}</div>
             <a href="{wiki_link}" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/{base_name}.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 """
 

--- a/generate_paint_by_numbers.py
+++ b/generate_paint_by_numbers.py
@@ -1,0 +1,123 @@
+import json
+import os
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.lib import colors
+from reportlab.lib.units import cm
+
+def get_display_name(base_name):
+    display_names = {
+        'tnt_side': 'TNT',
+        'grass_block_top': 'Grass Block',
+        'crafting_table_top': 'Crafting Table',
+        'oak_log': 'Oak Log',
+        'oak_planks': 'Oak Planks',
+        'diamond_pickaxe': 'Diamond Pickaxe',
+        'iron_sword': 'Iron Sword',
+        'gold_ingot': 'Gold Ingot',
+        'iron_ingot': 'Iron Ingot',
+        'netherite_ingot': 'Netherite Ingot',
+        'water_bucket': 'Water Bucket'
+    }
+    return display_names.get(base_name, base_name.replace('_', ' ').title())
+
+def generate_pdf(json_filepath, output_pdf_path):
+    with open(json_filepath, 'r') as f:
+        data = json.load(f)
+
+    palette = data['palette']
+    pixel_map_32 = data['pixel_map']
+    base_name = os.path.splitext(os.path.basename(json_filepath))[0]
+    title = get_display_name(base_name)
+
+    # Downsample from 32x32 to 16x16
+    pixel_map_16 = []
+    for y in range(0, 32, 2):
+        row = []
+        for x in range(0, 32, 2):
+            row.append(pixel_map_32[y][x])
+        pixel_map_16.append(row)
+
+    c = canvas.Canvas(output_pdf_path, pagesize=A4)
+    width, height = A4
+
+    # Title
+    c.setFont("Helvetica-Bold", 24)
+    c.drawCentredString(width / 2.0, height - 2*cm, f"Malen nach Zahlen: {title}")
+
+    # Grid parameters
+    grid_size = 16
+    cell_size = 0.8 * cm
+    grid_width = grid_size * cell_size
+    grid_height = grid_size * cell_size
+    start_x = (width - grid_width) / 2.0
+    start_y = height - 4*cm - grid_height
+
+    # Map aliases to numbers (excluding TRANSPARENT)
+    sorted_aliases = sorted([a for a in palette.keys() if palette[a] != "TRANSPARENT"])
+    alias_to_num = {alias: i + 1 for i, alias in enumerate(sorted_aliases)}
+
+    # Draw Grid
+    c.setLineWidth(0.5)
+    c.setStrokeColor(colors.black)
+    c.setFont("Helvetica", 8)
+
+    for y in range(grid_size):
+        for x in range(grid_size):
+            alias = pixel_map_16[y][x]
+            x_pos = start_x + x * cell_size
+            y_pos = start_y + (grid_size - 1 - y) * cell_size
+
+            c.rect(x_pos, y_pos, cell_size, cell_size)
+
+            if alias in alias_to_num:
+                num = alias_to_num[alias]
+                # Center the number in the cell
+                c.drawCentredString(x_pos + cell_size/2.0, y_pos + cell_size/2.0 - 3, str(num))
+
+    # Legend
+    legend_start_y = start_y - 1*cm
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(start_x, legend_start_y, "Legende:")
+
+    c.setFont("Helvetica", 12)
+    item_height = 0.6 * cm
+    cols = 3
+    col_width = grid_width / cols
+
+    for i, alias in enumerate(sorted_aliases):
+        num = alias_to_num[alias]
+        color_hex = palette[alias]
+
+        row = i // cols
+        col = i % cols
+
+        x_pos = start_x + col * col_width
+        y_pos = legend_start_y - 1*cm - row * item_height
+
+        # Color box
+        c.setFillColor(colors.HexColor(color_hex))
+        c.rect(x_pos, y_pos, 0.4*cm, 0.4*cm, fill=1)
+
+        # Number and Color name (or just number)
+        c.setFillColor(colors.black)
+        c.drawString(x_pos + 0.6*cm, y_pos + 0.1*cm, f"{num}: {color_hex}")
+
+    c.showPage()
+    c.save()
+
+def main():
+    input_dir = 'color_maps'
+    output_dir = 'paint_by_numbers'
+    os.makedirs(output_dir, exist_ok=True)
+
+    for filename in sorted(os.listdir(input_dir)):
+        if filename.endswith('.json'):
+            filepath = os.path.join(input_dir, filename)
+            output_filename = os.path.splitext(filename)[0] + '.pdf'
+            output_path = os.path.join(output_dir, output_filename)
+            generate_pdf(filepath, output_path)
+            print(f"Generated {output_path}")
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             text-decoration: none;
             color: #007bff;
             font-weight: bold;
+            margin: 5px 0;
         }
         .card a:hover {
             text-decoration: underline;
@@ -68,114 +69,133 @@
             <img src="svgs/apple.svg" alt="Apple">
             <div class="name">Apple</div>
             <a href="https://minecraft.wiki/w/Apple" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/apple.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/bread.svg" alt="Bread">
             <div class="name">Bread</div>
             <a href="https://minecraft.wiki/w/Bread" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/bread.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/cobblestone.svg" alt="Cobblestone">
             <div class="name">Cobblestone</div>
             <a href="https://minecraft.wiki/w/Cobblestone" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/cobblestone.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/crafting_table_top.svg" alt="Crafting Table">
             <div class="name">Crafting Table</div>
             <a href="https://minecraft.wiki/w/Crafting_Table" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/crafting_table_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/diamond.svg" alt="Diamond">
             <div class="name">Diamond</div>
             <a href="https://minecraft.wiki/w/Diamond" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/diamond.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/diamond_pickaxe.svg" alt="Diamond Pickaxe">
             <div class="name">Diamond Pickaxe</div>
             <a href="https://minecraft.wiki/w/Diamond_Pickaxe" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/diamond_pickaxe.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/dirt.svg" alt="Dirt">
             <div class="name">Dirt</div>
             <a href="https://minecraft.wiki/w/Dirt" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/dirt.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/glass.svg" alt="Glass">
             <div class="name">Glass</div>
             <a href="https://minecraft.wiki/w/Glass" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/glass.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/gold_ingot.svg" alt="Gold Ingot">
             <div class="name">Gold Ingot</div>
             <a href="https://minecraft.wiki/w/Gold_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/gold_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/grass_block_top.svg" alt="Grass Block">
             <div class="name">Grass Block</div>
             <a href="https://minecraft.wiki/w/Grass_Block" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/grass_block_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/iron_ingot.svg" alt="Iron Ingot">
             <div class="name">Iron Ingot</div>
             <a href="https://minecraft.wiki/w/Iron_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/iron_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/iron_sword.svg" alt="Iron Sword">
             <div class="name">Iron Sword</div>
             <a href="https://minecraft.wiki/w/Iron_Sword" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/iron_sword.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/netherite_ingot.svg" alt="Netherite Ingot">
             <div class="name">Netherite Ingot</div>
             <a href="https://minecraft.wiki/w/Netherite_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/netherite_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/oak_log.svg" alt="Oak Log">
             <div class="name">Oak Log</div>
             <a href="https://minecraft.wiki/w/Oak_Log" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/oak_log.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/oak_planks.svg" alt="Oak Planks">
             <div class="name">Oak Planks</div>
             <a href="https://minecraft.wiki/w/Oak_Planks" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/oak_planks.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/stone.svg" alt="Stone">
             <div class="name">Stone</div>
             <a href="https://minecraft.wiki/w/Stone" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/stone.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/tnt_side.svg" alt="TNT">
             <div class="name">TNT</div>
             <a href="https://minecraft.wiki/w/TNT" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/tnt_side.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/torch.svg" alt="Torch">
             <div class="name">Torch</div>
             <a href="https://minecraft.wiki/w/Torch" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/torch.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
             <img src="svgs/water_bucket.svg" alt="Water Bucket">
             <div class="name">Water Bucket</div>
             <a href="https://minecraft.wiki/w/Water_Bucket" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/water_bucket.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
     </div>

--- a/paint_by_numbers/apple.pdf
+++ b/paint_by_numbers/apple.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2811
+>>
+stream
+Gat=o9lF:W&OlHj'bAA4nY4Li+50k`P`<"@\FNC6(`S2](uF?BVe.o2]-%!_X-tqS$c;"N`U:<-6W2qS9E2U#It.C`3'KGFJ,ejFkDuP@*\Nn+4FM^,H?sf8I=M$:qgDgGmD&*2#T&uP2V"SPA6d=FGl$h&lT`/^qY^$]qW5biNuu+69YZ%+I/Eg0^HV\bGl$NHqW>dOl1j-tH`-f-+7C6aeD#T]pit*9_msTr\*5;!RHeiV]JmA8=8FTLGWu+TMZt*(Q)ogSB2XRd'<T[Wj:t7)ZY@-6:"8&1/I,!,H/i\e*.T]i1r="%XdC)cjoC"B-909A6hI65Y;q,pPKC@L%Ns896Hkl!U3"?NTK.N>Jgo8c%NqWbF@V$rbr$=f7TM(@,0J*/Ld%,):1@?@;-m9lPa>A^j^hF[H!05W0<:<W";^4MMn[TZ1hU:"r[ol`Qtk8i`<<j,MC<DO*5uM?U:f0:k[Uq6MhTF$f#0n)+=K-PNaf?V-uZP]m$fRsZ.X.3Rk7.8fl@dr/O[X-V9c=jMWRS;mG*+qrHV\Z"WLFJ@%`6G$,k/jQU$S*"Cea)5`VQAEg03>miY46MCC+\9aTl/8g$X7"Ce['5`VQAEYKg]UF:[571"Y2AI2g(/qeBoD/Ona6/QK=MTqH^fPE:r2d;;OZfNTR[_,_pCe$/<?$2U\QD<)K3QdgC-MqDu;/EZP*>ZiIVcUNJ8+sdG!LEUl`RA;h)JjBW/4-C1/1RuWV/s!)G&S]#gk4H:4h(0$jG)uLD.)n3b^A2P`XOQVLpMb=ERA$2EI)]FBQ($n7<@Q=2chUA2`EU4@\gu.S#_?cEu!(mF/@sm/V=g4aI1>t>#WL9=(U<YDf@k1KoMdr\`q=L-gYg2KTVb-SZp"C-S38K-gY7"KTR4VSZort:7,B-4(/@%-]H\um=ZK4S1m063+7S8=&NdX[10<E_ZJNMdZqc;<`mF4XsIVRLd#@EkW37<Rjg@2^)<i)68h/P<(O8@f+sEH.c'[_)jGj+7@7ckb@WeDe&4q+0$JFseqoeQ\88#U[nY)R_0q^8KZt/dD.)$j.k]&AkJBn#0$L\RAMYo5\!q)ab@Xpo6T<HuQd)nihJT2"m__^Gm*&.LCnr!n:&$"N)A=t0NQK%g`aU[2B$If!'iAX<LgFgI-!I_;<uTi/6=V6`VD16CCM`(W1q(5S`YMfmCkKnL>@=/0%4j?Ei'Lq"DV*O2$]T"2Ts4b:)Va1:@jAHV1q(5S`YS/4@iJ\(fXqo(@sVtCfZ9Ut9[j>)-4:%so?kqN2U2!W'iAX<LgFgIG]Wc7KuGsKYh2438PG34&f\&diiikC*&_2;$JWA%_WJbQ?lN&^Cd'BQVT3k29rE][2Q6,sS-j[]@%jba(A?It_Ht]dmIJuHZFm'PG'E2Md1t,84R[j-'6f<$J@f@8^g5NZ'"m?s.>fP/,t'EBjXbPk?Mu,Mo%LlG?6aW*00Qf!CVb_=2Rq,ca=S'TD/e08$S2FhJVClT`rLbV\_UY7/ekaFKu2umclKR2Ku4\d6=Lm=88RA4/@NB+Mp7<VCJ9fV)EW(djtY7.n<e#3p/iljfT\3W3)`5u@oDsAA$Hea>e'VB#^^@mb8r`R-Q_%#_IG)KHYeJ\*a<X;@lrJ$a&Z=9fFF31[c4U52Rr8/M0o2!C^8-)>DrrNm;U`g.kZ0bLW^`#E@2g^iBBB4(`+7J^qsUE%So26H\=PZ0Fg5=p^i/!`$?l\-J;&Xi2)_ph6>((5:u,';Id>(7dS>kH7Yl!^d:Y>/3@RA:0q.A:na](YY^K$gPn&1_FSu&KX@C=89uh71dB^^,<Zf'>"f;El*2fXs*ABd>6?pLb1QY:-<W!2^L7pj/+b#Ui>4MsJe=04L8":FTj@V=U)QSJm>;dlEMAg0/fZZfB9(['Z=F_Q87hr3b:L0-N1Sc]1NFirHoA4ubQ80uCiCPdq([!=CiEgOq3H0PCiEN7Vc(`<,PJFT7ZOcjjKcZ]4G^j4EYPsEUMLl(f``Qf:BCj"\jgo%)B$]pX#oMLf`8o4,C&c\+*Y52O:aQ1a9ECa=c<`@kdfLlF"Rm,JV?DPa3Y:$_1b/jj2)oXgu;%#XY&/+.n!Y8D?W$-/'(SrJm:pV!bRb#TSTlg'[_[Nj<Uh"LiUh<kc*au`7l4g6d$h.bEn.Nq%!/Ho+Ui/juZPFq#\_khnYuJF"EZ*L['ek*D<H.7EKb`Z'edD=`V(6o%"p,7o:g+P\[=U5&.-3%;O(YSt`Z6'Xa4$>[&r9CF_nP><.Qfb#-Y]NhS:<'K(u9fPER*AX0#m<\`<p<K:NkjX;d_OF4]DhVI'?:MY=MApJ36-mj3=ncRM4T7;1dqOcsF6_.k.a>Yi9#NB/sb*D\@=BfMK`udO:\mh_6,"28J'1,F$s+2TrnBL!1p[gc3CigjX&R>]sq&P"RrUC]PA@:G:%-^Ou3pCr-J"M=I8?l=t1'E#J?sHIsD+"(4N@Vi;L@DYq5)!H1NC2&#W^u;_*6hB!6dR>,qL[cl6qGif7jG]]Leo/]\ep2.1dm3bg@=W]RXBI*U5*A2hsLHg\s?]/#<@?]8_/@>FjMLIWXUU[7%0iukH#W;oV=piD$<(nAoMi91fGs/Y2`5Di&XV#,T>Z0FMWt26-m4R6)()@\Za!J-JnBBgr/IQR@aHS1VJD93$(E2oM<:<cs@tjY=;i("Y9.\=&C#WUq;-H:K)Z=k_`1!;fMA.HYY%#JcF1N]]Jtf(<5Ohq^K&Dr.jn8_om*qHs+]q\+#^HpKJK,hsSfdT5qPYjeIe_2=t*D`AFmC)fHm(;ek:[4ktBUQTd%^na?GLiu&O~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<86c73803efdd047a34f4ea436dac6c34><86c73803efdd047a34f4ea436dac6c34>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3814
+%%EOF

--- a/paint_by_numbers/bread.pdf
+++ b/paint_by_numbers/bread.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2800
+>>
+stream
+Gat=p9lh>a&OlHj'iUAliWY9Z%($CBFuIVmi@6pSc.J;=[Ep7M5Q/[T(O5KNh9Ai_`+!#D_#Slo`A]'[iTX-_rVPd8O5oL#q#8<QKQoWZqZtm:j8#V5LZ]2OmuKu_\+dqlS`B\-NX5H&4f.a`B5sWsIQ[XZr;#fRs82BKq""7Dhi<27rf,e6GW^D&q>AECNp$E^cemOqXrRK=i*Rr5ptLT$$I7C[\uYSkHoXNl/k03.k)2<24c^FcD(W-b`n-R;T=8L."nktSd2H8(q:%gYlsbg/AG"FFfRkLhkoP7IRV7O1Sk66hZ";MnX,6Q4C201H8C>$`1tPM`]&'2o"&^_Reum\VFIk,HW`_Rs_>0HT)j"!=c$R\>jAMOdX"^XJ9J5C4'uR&-nusU<pL0>N(fj(iLK+rJ@9#^@=;=[S<]S=?.O?Hn-+^c04+0d5/tZd('j-hs2,1N597%7uD-JXE^quq-CM2p:/pG=PV-VA(m',]?Hk>M.,'r^E@_C*ll<S<"Bh?]*3Jr:-;=9d<*;u%qka*8X^Z6g>,t+XCLie!X^"sju?3h>l0Y44'-JAj%jp`*>2,M]TM&I2<2.0;9$(D^42.4hc2&<#G@(EYf4W'a?;_ssK'kfN2UYk&VU>L")d-oIhlQp9A/P"3,3Qh:9PG@#U'`F>mkdM+o91ua\3o+)EFD.X\Pnku+@,Z^*)](9VF,(09DSEQ1!=Ki_Yg@rP$QX&nn:?,u+)JFuJq;*3R'C@6"?goF@6G&e#mN"&aVi5[dnh*rljpY@n40.T7Dg!"rfEoELE'lTLrnTd3=:6AdCHr4HS'O^YF$;H@(W]GA7OQ'Ch@KiaMraaCh@Qga@=JrZC/8n=uHR9A@'*=2?kdEZejO^)Zpn^fl/)R".*T*`X^\cYsUG8m2`JeE$:^=]9&$-Fd>bddH+&-P@^MFZ>:6&]56ORA0XP+9%*,&S7i\OGE'7^AIpb`KaT]]gjErc$^],F_6TI[=I<g?AMY46_b=huS&p89R:^9H2Nrh&1X4^"D'fW,B%h&'S&rNY1Te+eAhmbLRF^*m1Kh4Ae',K`P<o[3;sga<Uj:3i&VZY6.%<e!cArQ`EiE)C83:P6DGM8OW#KDDc\9@[\9Xc&".(mRj$I5[mTj<a/2UtSZGq&mBM?a+`\q(8b^a8amBFs)J]esYi%A?lZ#EiU]CeL##4>c,&(nke3sI5m[OKtXR"<F!Hf-M5-<gTkbK]jhC7_:NU<o8=S`SA6X(S@-.Y[#j>eN$*k8CLChMdF%kNTOpGr%B2S7gcsH(4KDGm5l_DhEc8$s5K-k,t5Pk76[W\T",@$g2B2E1VUgkA@_JSq.:4XcI<YcbO,TXg,chHL,V-bcM99)7XYBb[!2([M,/IZ_RQ]BqB8mU2Z\8]l[S<me3n)jVb!nhF,Trj6<hdG\\j`B>?iYCFjjG^p<DUC0KiH5_\VQm,I\a"*W=7\He4eJI:)4WGnC/$eI!)@&VA$L$I5kR*L4ndk)Ls7&Qpmd7r9!n=6EeW(WEbeE)<u.;Bp\8^VIjcch/8[hV$M\\EI92*>O0_K.Ll?Am*ZL$3.8b&hst0\qHkeJYknh1c<h)7]%E%2Q6*?m3.M]6I^ki""MDf*gCPYgD3PaG0-l>ki3SL%#LU#]F"W@6=XYNAk@j6@#:pL;r:&CJ8mbCFls_HmtLsLf3k;A,0q?N-+`#%N;Zm=^qutFK$u&Q8SAd?"hHtKuS:@esM07)V]77@i"K<@ll5Wb^sDcmC95P!uDl&i*JYBZs[$H4"P0k_I\^D8caoS\?)q?DRn>cgio\g&S3gKU3AIDHil7^5=AqWII^90Pr:5DX64mu9R88&1h.>.dSlj920ES(N?)&gYq%?hZ&mB<$Rt>Fm%b(*:=<(7U`$f>3`;"Z7Ts;1,Wul/=qC!3OrauQc.K>kO]9>/(b%HJ,:;@c1!+_RSH6>V>G2iVHKc5,&"i^QZ[oRSMh)8PbhVNfh^hkHB#^t^UZW-+Cq*<#JIBN"[p_89^h(W(Y`OeE$d3@rY`,/81c'3V^Xq7mKkG"6=a3F&cZ"XZKfm<;Y_O3P53+-h6ad%!_@'3H7#5.V,]p%uN*CiM\.Ha*]mcg4JqZI%m,HuqJNF"?iBeXk/d/K=66HIb$Y4mD5R^a#A:82[+F<GeaNQ6f!YOUC3'iSA$$$_T&>R,LEYM91U[/,okj/GR=a#B@au,N[=#EdedMq<-nK56q6KONZeAZV`)6bOb#0S$r@(G;:/6CVY]iTTpZY6k&apjuJjgsC@aDbc,8a`Z(b+2O#3?^o?.RfR`X,,UoX(W;1bI=D5X;jZAjXBk"87)"O-I)G=YD*TWe8n+lB5Uj/dD/0a2dB>0^u[%`Yiqg+&>NTA'`F2Yka*8X^Z6g>,t:D>j='jN8%E!t@GQC/7X4ls)Dk`$^JY.;9[0CNh]CbUo^_=kQX=&_:5AYPppD,!!nGb'>jQR=oWR^IoQko`oqC7AFO],?mr9eIjW&3c8tWi0s)JVGTQtC],IAXU&dmYh6U)WAW[0l`q1%G-jR2%oMfKufA_Po#,Mc:knG=g[96R#*pi-%"QTm^b)Le&,?W3ZQVsCfs!j*X'<q3VQ<)-U1/acn[8F?DO+nHTbXl6Igof0\dk?;W*Pf&d`^YuVsnBEtTP,OK7$1;*^5X9PioX9WNX*FJ_p@rS<0fNH#?(H#,:;jo<bi<]UCDAghLK,$l7J\b<i#g5hp=n\C->=+kD'hj+[=**=mofl)jC&dg<foTm3hUa5l"pjmo?5m1;GD3._hkTAhfg:3rc<t#?_>arkgNiDo3<7WrXYj)T.'~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<7c1210d7f20bb63848de06c7bde21fee><7c1210d7f20bb63848de06c7bde21fee>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3803
+%%EOF

--- a/paint_by_numbers/cobblestone.pdf
+++ b/paint_by_numbers/cobblestone.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3222
+>>
+stream
+Gat>[9lK)\&B=8;IL8_QJ4&@G[CnMb[gQF`-Z0:p&:u#*&mq9&0_JC,Eg?J-OiS.es)b8fIYg24`+A=SnbM',rin$C*gTU9N(Zjf_p:t,Te$^]04-iSH2`%l;Rq3<m:"V-a*T#M25GE^bI6"6O*3&bIk2[joD\L)Vrd1AO2!=)^]1_Aq<db+T0N8Cqr?T6r;$![dIQe]o'l1O'^G8XS+X>bm8n5ole$-JmKi4Zfq/$fBd'=\0&'RIT%^oS'\^"7:&j_7j7;#?@B#!OCL"=I"iXNco>9MV\U-:0YNa[XeLc,M@nPp%3d4d:FXoQ(h:BsHUR\slgtbUo2,W$OLYQ))Z>"1784R4%WGfm^nojGeF#Wbd>[+):I7q#U*o;/=#X[6$FW=<:P'f?g:3J/Hkj,(NI7Mkj-?m,C(0]RnduaHmo^%Lb:f#o;erV+6L"pmJUn`7ZbpA)(8CV@pI7N;N?CZanm^=$;4/gViqj)&FG#(K^pQ/&.k0UT5[-0*N`#.'iWRF]?Nc\3_[qd;QYcTEu)G8nM4]^0h;Hk7S=W^fq8#kD_5]>CuLui:Y^$UWLm!Tok6jgV$=6Meio/43T=6MeilQs5<<p2\XgGQZ4(\E#ZTpP!N]r,bYVO-Q(l#ij2HC:k]lZInfU'l:<;^V,l=eXI#2:0NgKjLr5oJ0^Gf/X;5Qg*AkF_h&k6l,DU@fX29=6Meij!DB4<p4[lX7WhXPc^QKL>LL0NR=#Xa?n`,CV`YS!Ul+efBs8O\8*]tfq$G=]0eIpl4R6uC[RRa94S33HNl0jW5;e\_j&sPXHI@2+YHWG\E426>TsPpc#]Q7&m9HpSce)?a9oCD[2@WC=&iIGZ&1,q"h*PRJ@.c[es[PTeE/?!8'MaUV=e9X_mPfo_HNiFCl'dK*P7'76l+L:fk>=dhc4R]0rVQL(Z%2YJ4jtf>^O%3/s1jtc?MYCHrnFtf*cYV/BkMgX6:1%TPO"bW_7H-Xtp9d96>mD0q/VrkHjHV]j-8XkQ5(;]TAK$6JaG$%!lCm1%(0u2s&E<[9[o@0@9s:@lG=u&m`jGG1/=^6l,ET=mH.,HroPQ]@ER@k^qZrRgj\#Y0^r[=6V$:T[t&7kah/l^%Qb<09HFO:)<I7?-mAZ#,R[MJmS=2.(r#Mkd@`hmsJ1#Fh464k^m.<P_!-b$[Nh6K\h$N:eH4F1A%_bf_Y>nX)"Ou0@L*<A(RB?l%7csHi:;iP6JYn(dKb%<I2]gEG_',JmP?*oJ0^GfA8C3b@Ep-fM0ui&m_>Xm$::jR4RR0V[Ig=0'IGh68-dk^%U[o]hDMk[3'1WQcLYip)$%JdfmGYknSN4/EjL.X7WhFCb8S01t6C2a!+gG+TQhFY0_O\2M5>1/+fFEf0Ap`=eXGMY0oDh"hi3+Q!U18oQog,]gVTiYEoF+6rrM7Fc?b=6l5JVVZHE&=eXHjJmP0%oK$JYHASfOl^T`,Qg!;jF\[S;4.c\ic5;dPU+>jsgBMt\XO)=:<eK87Klq=`*=]FM:N-F%Jk46]F@!+Z"hd;?oT%aP9eVV4]lmH@SaS&Ap)'$#U'l:<0'FUm6E`0Lcq@n8n(>$slCIAn^%N:.09HFOA%!<J&m`jGG-aIfd075WGa2U0/+hPn60Xrd._YPY.D8+co\*dT]gNY.3g>3P<'pUnR_#8fjqM\A3k+W7=i`[8N@3DH/DqPSf6<B4<Ob+iNB8&7XKlW%<n/M%:tNto>p:f_RN&-d&lk;\A;tB;6rqDecN1s1WY!ceXFa)U!NquI[mV"gg0&AfA;+7Z*2p=;<Ro[G!a?iVCkli;[[*l/>2)GA]>h):7,?6ej4YRhX*[>=dtP2>[i3m3?!oa;NGH-o(>=dOlN4tO=1K?`QFB6uhE's+\3sE6Fd<DTM(HSf\fc42X5quEJ@S&`juQY<96>`frErQHM([;ca/eP>?")>kY.?]e<Hmj#._J.cnCfcc?6Tc&*?p3oZ5mAUQ+E`als"tdjf<"p5qg\%H;@i,Bf2b<oQoi:e&u9U?>$gAQfs$-B=X\%kmG,%Y&Q68e%O5rAVFG;/+fFEjdKMM$[SB:$GB,6k]KW&k[h=lYLaM8RBFp&NBuc>\p&Ik>m%c.(A+30`Z5L^=6T=gGC#[Yd!NnRf64":aP6RZ`HM&n*TWd;!o>YI_)n9C]1uD^SZdY$Z'l)EVmED+PD-U>=eKQV5gc.KMRiF@:ikg#+Eu$J^SNi\<H6(Goe39V<Iek'R"@DlKssemhTfcMm?fb[6]K0E[e;^XD5XFlXaLZng\ED%Fg>KDHkk-l-A#E(2.LK1p6lNd2&Vc6YT:?qdqDDkg5b"TbIL:^gl>OtH7mTFDsd(p[mV%jNa:tK>bWb.g='&AM(H_j`X?hM]5"Ksb$Zia"hODJ'j[OAFm[YNl4RC,CS(fBQfs==p2nj@q5hI!F9+&BKtR,(+YSr]]aeVH=6@?G)ip"TEaP#]l%7csCL#V*\tF96?=2GuZClEc)V9.hY0uWX5qgUh^%Sl`]gPrc[AU(t&m<TIMuiRrGEq$i)mAKPZCofUY0osb6*J`@]gN\/3b&0'6s&T[&"1j-T2g3.0'FUmT[t5<kU!O-f:FVY`L$sXo?k-`QbS(onhO@1f?"B49NL'lZe$":RB!bY<fQFV6l,.CMhS`9<n)7m/*JbA41\qP\>[SM`E[&\68"B(\b9]*>c'"13`Q3IaU5QO%,`_$'lWI[6]K4E\[<Nh:lD8=>C3`mQH9KBp'elCVCL0N<M``>NhNoMgq%Ck*=PUXerF%r!X$mT[a'1f>9XGlmAt=ihc4R7Y&T#Dl,$YO]F$:='l]`*6<k]BELlWOh"e+9CTeQ:&m:T;03?OI\j4m36=$;nFm[YNlk3T4GKa+*h>+.`4*HU]d?lQE[Dr8mM(I_q%b\Jo?hH?A^Zo`e`*^7DYLoASOAl#U%^`D]IsHG<l1+/af#9-ILQZ0(o$S'2<k?oRri][(numE(;O@BFcMCjkrBpUjhL0d$jl$,&NGIjdmORQmY5`(Ggs=a:KD%b2]R;sp0'%H*7p965IpPP.?eP$d@_QRhWKn+)S5+u5[me6igUN&?f1sikh=Ctoh*[-:HJJr!G5kk<E<WnVi6ujr4,kE&g5b:Vqt".dD\X;8rgimcH]a=$qJbo,5Lih4e*V!W`R_fn[4EugT/Ye1X2&>;<`/`DhUUB8\;H_ns"'l;^Y;Pdr:bJ(?F:,VaCuBkY@?D`D;U+K/8tLiYGJJU~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<fa8f3108d0f40f25f2dbf974825b6fb8><fa8f3108d0f40f25f2dbf974825b6fb8>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4225
+%%EOF

--- a/paint_by_numbers/crafting_table_top.pdf
+++ b/paint_by_numbers/crafting_table_top.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3435
+>>
+stream
+Gat>[:N,(/'uo4G56ZUUg+9,mIlQ:RY1l[^Bsm6O9bjQpi^H\:?b^Y.Sp,o*pDi[&![P(5r9hr@q1toO(cFVX%^5p1n^hW)HJ\YrkHKZM4o_mCm.0lJ_tNp%_s?LG(A$qbEHh<XHoMbT7i,so\$d(hHL9JYYM8OGqW4'1Dqh`S5Q8=oj3,d/j,_rmhnK$\hg^.Q\ikQ=k:\K<fUi,L4b%[6\[)2&K7D/Em4TQA;>/`pG#s_@r3h;U?&ZL6bnmk0\o0=7g0/1]KAU"D^Ro+r`MHPNf#H;UC<<ZcL#o^42iTJk[n:f7mX0i\gl:K7%Bd(N;r-SAh0V&lHZlY^.bg.[[8q&\U9C`?*gggb>N0^=kAE>)j4Hb,'@e+-d\?3nDE`9f3:-?,*=d(*8a<pUD;"S:09mP>i`h7O[l7AeUQ1'c[U`pTeP4H''W>#&@n1S+`Q[K.HB6S'ON*:`?^o`N`RW\AUEPUKBm]-r;3pq3V-LQR(gE0hSIO\Fboo%g'6Q.mYp7.#dtXBUCYhu[6QTI;LQ]o-96K;]2AXR!*fEUccs-8*6LL,4\+\bN51\`pAO8'!'m`[3qNtTd/+d$$K3flToU`AQ0tfskoU`Y]0tg7^kWO(_a7M.CK3g&YoJ0RCfBN^V6l5J6?(mV,$GBJ@k[h=lYLOA6RBFnP*+be0koTI8-O&][ZCof/LI!TB'md"M5qeE:H7^=,DtP`lEC;SSf&:BMVS#;4nh+&S?6Tc%QY_!7/l@>796F=g]q1e]l<1&YA>-/t"hI*&d+,0NQ`.c+4UZ;6B.(6)(?,s,LoXSX/s-=IH5>?M=a6u[_(CcaDUn%%p3LjrX.Hg7>9XGk<G#Vj;2)EhM4caaf6U"&[CM=:8DUkn^iX#Pg._p_6l4LYh>OUe6l+LZfrf:@]c0<WS(69Lnp1IE+q/FMJKZYn'lf3aa<e,7fBC*,leUX..jJr70@V;ZZ+4j$'tXitM/_m#>U\81`0?So\*-HKh%%>/+tWHQ4#c]CSt5ZA-h>cRkX&Vs*q2g5_6;fCr!gW!YQr>.R,"(04`V27&mb:EG+7JEd=o>N=7MWu_V[5Oq0Te:06d)#R/@S&n>e4[jHo';^W&$Z?Qol,NH)f'p$TKRe[s1pa?ncAX6N?2ERejK$[dd`/piR1lm95PYC8H)H`q([^&#7f?D7gSos5,$&m<k&(b,0E*aR(Ob[g)5hR2m5i5,A@fZSAFn(QS>gWO\IYL,N"A[8OabprE"h.a&V0'm/\Yh/)r]hGnW(Y[^1hI!8j^.]@<Y2T'k?_TXPe^m+VA[8i)TH=ZJQg)@nI2QEGdtPKT15NV;=7"J(!VR/ZBs0]Qlt*c4fB=:L10N7F(^YP)GHE4WN=D`Oj04?#riC7r96A/0;cg;lk_d&S=6q6=@dbbHfmCC?H`\pe-+^(9_kHdFpDuoa98&?6?Ya!#94Z"JWsa9XGB)NV=pNtYF9Q#]hMEo5'n!,9n0PYdf>1\skY$R>I>rNM^=T^<f/Sbf^-l&p[CW(cOVN9r-)#6pcL7$EDaPu6"`@pTq@[)t]66&[M(\EX\tUj?Kt_>'e+\04lDot-od.1ij_K!i0@:M^NF`+(6l,P9ir\-(?!R.C?._e\@B[BRdpAaVH]<#R0@?$m?`OQ\M6>4+0>jU[H?R`;O#uSP\tI[=$GAhCoGU,LhO*-/Su1B!:f;Bo"tb+W/EC*B)SAHRnEO.rQ`.dWV5geI4Zh=sLRm]C=fAB6JM*'"FS.MA\O71plGJ5/le+k4RYA7>(#l6/0Yo'@!*:6Xh@`t9X(T7#OVMca243*(Y>/rb@4/KO(>.nTZ'M?*>2;SCl[rt%;X\HN_2jesGLK`i$Z"@sL+UdV[RO?*-*f\DOCLFdmsiXnDm+rdjp!UMEJZC;10@tP98(:>[B#uoAG>$U&u%NBfY&>t[i(,Yi$Gsb='pb40@>Kd7Mk\0?/0%recGOY@DQ$;GNsN<48%.MjN0(&"i!N.r$AZ<f76a!cE008$MEP9]XMn;V.KbPF9UT$<rn]Q$G]^:!1:k8^o+7<0G2;.mjY?N]7K4h'sFkPi0W[LJ&5g#KD<W3jeC@q=84)Q\EYs&=7g(0o(E9'*Pa<A(4M6c!5D3/Y'd@Skf\&YI8=!7?Qol+NH(XFdhR;5m\):t'n%Y[U$pBAn?$3p67pbMbD7_9?*hZmbD7_5?*amOf;iqeiD`hF1gJ@%GP*h\mU"4k?%!//]@XB`mTNW@]q,D=`jA#*Ed!nPB4:6$.`aI_@?PuN$ZYha@>]Cp$ZM(o!4^XeiiRYf9Q)Rc-b&rVPM>D+BWEd<[(TcL[YB[T<i0K9*Fnur+8p0Me<]<MgU4*[*!OfF[qf(8QH0-_262:T]fX1j\e(4lb+48c=1cqsKTA2(f"<]'a9#YB$ZrRrVn.0jl4R71cX:=X0$sj77MkD(?+=Zli@`LmGkLEVpNh#*X.R=/?D7gRF`]l%ObLK'Og%p<K<[B-ThdM;eA-07n(Lcj@$p2qhR37U-\e$?ls6s?Nsl]XBs5p<]gN[']1*V/&m_3_aF[_B$[Rdbke5iDo]f`/94U>lOTiEd(\AVOcqAIHYL*Ne6s&U&Z]j83fh&Ar%SqD-0'Lj1!PLl:oGU+)]i\luhULjFX]SZ<9NL4[ZO4?=<o>j@LV$5[gg-u'"*02KfNki+4U*5`lE47n>paokCK/8XVCL^H=Ws-QJm:Ghi\FLGf;K%d9NJqdZJmI"'lWc_$T08XE3#T=:lD8=>Q)JD[S0`+26r"F9NA/O9E_c/Et#HdkIb`qP8]f@XBiG,_3X9dgU6qR;34Heg?R]nDQe73[qf&j'I;.][qf&j'I;-BE/cEe-*e*6k^qUUh+=d+Kt0Sejr.Bq96>`fd=o/"([C9UfjpH5$G3kYe(s?Cl)oIF:O%^Ki&/(i09Lt$g+ke(4UsHa4q;h-nW+^r%%C1:.E8i@U]']Qp#XrC?9[5T*^"Jqq7ca2`T')7Esgsb\bX[_hnG]CpU_ABkOFtVqHimk_>(=-^,qo64T;7$[^"CnU2e86s&^<D'L$EL$U&&#Bc54lP.Qda(JeJ<G2)j+O!3NXb$L^)q5tlMaY'q7:IE&TK`CD2r;,f%f`!eIQlq^#a\]0.Up@TD`in5V6u'c'O0:pH0glL+q9S@<\Vq!N`k&i9J.&i[mP\R&Y8C/tDq4=1N7bHU48q-**](0fH<fn^%nf6m[mORG;l&/7gh&Tc`k-u@At4T([mT0P;#Hs:+kj1/AUIDn-^IE7__^3;`k/+`DOdT&@u@0[IBVsnmHRd[Is^kKd!-MlDEm2DfDG9:*KP>g]qcZ9oZsA3o+8r+$l%HXf"E+Dq0k]f1WA.2Fc(T@nbqXEf]aAMYCDO55F*S-NcVrYn!RX&a>ua3;j9%"c_lu6O-dPnH6#(iPN(u]G<8]klQtufgl^mB\%O,<\oKl,TAidOIi#G>pcl]_,YJ~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<c5b098d75d042268ee7c3f0aec2f348c><c5b098d75d042268ee7c3f0aec2f348c>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4438
+%%EOF

--- a/paint_by_numbers/diamond.pdf
+++ b/paint_by_numbers/diamond.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2814
+>>
+stream
+Gat=p9lD"?&;KZL'dI]!%S_G&jQ=AjQZ)tt\4'f>7#[?<J"PHf<-=7im]+t`@EWuq9^d):cgL/@lS].N\a09Fq7LS5*k1T%\BXj:n[Hb3'=Z#CgV`'@ld,Olj5oI<RbE8ZG(^7KA=MjbC,2sR[QT)r^Ad*?hbVSQo;>spfREhl#CQPp]DqKOkC9(QrFUESCO?!Q68<3OpPlk,If02i^4pqo<&8eadduU+2W!2q'q7ni\Sg8n>`('1RkIRl:R>aF-+8s_dHjOVYtC`J)P=Ybl"r?'2^aH.G`4Nc8Mk_QCQP%d?_V7bPseh23>BRA#i;$.,f^GCS(>75"GE:=c:r<\6EMTQ/6P5[c<)/6-Qn.OMRAT\&5tKm;anTmCG7BL//VDR'Sf["h1q7kd]a(Q337][%]^_0_^^K%YjtX2<^@@R<=m,X'h!%Dq'Z]Q+H"&dM!i/1Qk^OjCeZHgH,6`U;&WJ!MSmR`qloWg)HK$o_obB&k;s1b0=8otK/;NBp"@V":MSop/#[D6Cq6-p.@*";`s+M?5`H.&ogM0#1E:g9.k5\"h1XW:5"aX?UV0lZPe+h(Z!7->;n#(JV55=!(*BAjnPSWgS*\tjUXUkB3fZ*\]]*e_Em2OWd*?6mMQ#HB&P&pp1f8h#-8)f-76.hYER(C5.^7FA&K<'.<,c89SBYWQCV@:Fi:Q0;dGA+l9$QImfNc-Me6E4p1p/l2F874AQ]GTsfjo"R'-66T*hJ>l2V&*8B;M-KO_V&W;U%_7T@@,^`L;k?32sFi9/U'qWTJ5=YPH76k;?=KWTGFK<c\G2C-H\0Uui":Ce:VbeMNL8Q^ki$H?TE4,q&1ZF95f@F@'a!`!B;e4$aEH-O?HY'=d,u`_6aej:(4q>#W4^B15=A.(EP*,M/Oq7)L=%N8/Y1&.KEZ11J_C5VuRUaF]<O;/j-47W(1#L^$KRR4jm0U>_8#k.=(ad;VZ",<)5&7)O^1M:ioS7k^!@pf`hs"OUL5K!(;RE\f!HaW$h'.*74)U264XR;>d#0FsL/N#/d^F%J7pmS#MG0$<=lS]O@;h.<or0$-S67G/Zj@3QXNQXmF)0?H\77G05XgL[/<U21UWen(W7U23k8P)Y(*bN=>GabHp/QOP$*g$i8pfu.?9c&t#e"]:El'-.fcXN@ld/>`R!"2k+fKoh]:=>J?]ob0.'\_Tq(2bqSmi0'KDlQn>9\7hbYElgu^/=C4g,r<ZRh+T'fr&RH&,r7-WA0qJHbVXA+`(ULjR;(a-?3VjgBVtTG]:%a4#Wi*VGVor6N(4dr2*r5AKgQdMdD2e5afPt;PVgBJ:Gip#\btm4@L=SfCnT'!-HC:d%G7)d'NfD.J.30G.BobTq-qHR$7Zp0^s9+CjOc)h.@0n.TT[(P<77*79DTR2D.5.%QL$J:BC\r.;-j?Ijt8[%]5,4-eA\G?eAY(8e7G1"_+X21$)44J-@2[EB;#t3lofi=QNBhJ)R2)Dagk\`$SL+*_'OGfgcWuNJrBIDZ*QB`'NjqXJkH0/F1]6M>V_ZJ9*Q??EM>,jQP;>uB+@jZa^HF':*c^pU;Z3HDD=/[>AWBG1ra9`1r]n.2&8h@2C6I^1I2^4`^S31(2JK<KsNjGW%e_s20QciF,_WYUp1#GnfgcF7?+FZW%ea*f@U+.cS_T9U;g5=e<kh\)I%/X@i?n5CkY<;Bt1+H"*\cQ:;]M[Xgk;a%<pFV!SbmWVSJA7%buo\G`AB9"Mu=AmCsjL(n2e-Yt<Hn3d>D9$leR(faWpY,r)i$BuJ;m,fc(37VnVT8WH4cNRU'fP+5-6>%#HC@Vck/*(rV];oqN;.euVq,ot5hXQrE;,o\F:9/_rC;+C.0F;]((m!<*(BG\,6,Ssu!m(u7a074K4_B_n\"4LaI41g?s"XE2V(JJtR*4a?i'VbYl@n,t30a]O*B#Mt?UVN%((0n/(SD,nWkE9Ek=RsZ;9:f""8Mp$El_76qaYY5$9h_>?U2&hmkc/'<fj2Kc;)WgTaYpX?JSk01fnPQ^D:iA8#ST@LM;fEjb+IL*kl+CtaWDb::&L^CU-D-6jR$^lQMe#GP!A$_mZ3KWrq;BW9E&%$aWCjBq.&L2Y+$,1o#H.#\j+h5mnVf9j9.Z(:>dXZ:7sK9:(Th@$%hC/"?oCP&4Eec>kG,[Tk0GRl#dZJ>_Cj:^7\rW2,l.&!fJ(#@&`1-/66"C`JQ=IfPh98)ns*s_>04e"<XI@$)6'T6$2RsTJG#"I!C7gnkn['+2uO2akg/a8tG(=e3cDljl3%7(cFu4i0-"MI$BANO4(8<d6=XZP_PHaiik2[rUU*Gp%&5mCsP9uJ>P=@'>/h*chd1rpS[1]TAC'#Sp_r:Z#DQ-)DEl]Ri6Z+2$UO<q>JYT>7D8i_G<i22:_[8XRt>Xqr\I)0-*7"+M_nsfFeJ=+#^jh^2gCOE]5Pp?.(B]o^FhF:@Yb[q@no>_&j0OiK,.as2Ii-J-L8.cu9pt3'?j2Eqk`rER+F8%NijmV[qhH"!%;(_9p;i:W>?Z>2Cn1Nj't0-4A.@a0Q9+LW+h6D`[1a2V!PK77:6G]R.0'+(':\@9k8^(3/$u#[_!L2SRn$RoVfoEEGY]<SY+qmiKJ!;<&c-K3-4pF]\c`a%_Jbm5QX@_]laATAGP\PMu2MFmS'UC!@^a&?^q:[3)?bg\.E/Ik,_kVS1J%VM>iqBAtZ[Y_]r9&l*q/#QJO'DHTEcO)Yp-ZALa==,s>kDLb=UWQ9$ImeuG\\RcM(6cN-5b:;@-fBs-LfZ0]R)cL,AoP-lo0eN3Ij,RXX=!In+/%a$EqZhI4%d3QJ5H93-9)~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<e2aab50145587271849a823b6ad72e3d><e2aab50145587271849a823b6ad72e3d>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3817
+%%EOF

--- a/paint_by_numbers/diamond_pickaxe.pdf
+++ b/paint_by_numbers/diamond_pickaxe.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2497
+>>
+stream
+Gat=o9lD"?&;KZL'dI^L*1Hm+a=Rl3QQRI@M49ct,X@<Q$iGBemB,Xp1VI_7'e*HLO5Hr$Y,>lEicU`e5ORM!pKtArl=TqmXkTB'DLUJJ1i^-Q[p@n(Gkf#1Houi7=&]"jh)V26PB*^.WQDZ9gNN1"qt?rB^[CO!qqLk;[bksedHalg&"ddTr-eTRqt]j\5B$S8qej%AA%R#3$8ZDnkCn>?qrPj7k>LU0Ls>#P!Uhu1ZLQeKXk70acZSj9jAK7I0>?:[^Rie;Q*ui5BQb_f=>acO`[@r4^!3GMjts$7F0mr@d,^1i6*gR*7+3PbK=560.%1;FhO<@Z`t-Ref">Sq6;AljVHJFGWsLLr$ActFl[rdM@L/i5X''t?ZI(7h1i"F$>\mQjX9t2]<Ipa2'pI(I$C%#[JTA(H:i9;;b0>f@DH6q_c)O%>=VW>D.n6@<'du#A!^/KCU0"-nZSf#7YZEY37\s6Bb0::8hQ.QZB#U]*.mSm5Su:$Fm<!NY,0i>Vp"XL`)uFq)PubbfLS^BXM?E_-5g)WrnNs>PZB.[/*.:JH;T5bl=P=3sF1Du8*l>VX*^[5\Lf*[RU[0/T5WfIoPa6p@6]?nX(hF4$ffd9PGR2Yn"$4-TD;0*T`eDd"4:l3CE`q*Nek`AQL_X^Ggb@,VTA-aoF5sO7$aJ^YKieq2+]lUQ01.[B+d]X5e8VZ3]&jC2Zm@H=I;IWVp5u#/NO0qkkEBf)qcoO2cl\Yt=C7I<Nc)g@Fdi,W;4/LCjnSr!5!L_No)kaC&cd57&puC?eE,\DHm)N[_O+OS,=.sV8&@Ai7`%KnN._SD1(k@CAL*5FEAA.BEb-M$aH_mlONSkWN3/;+TTAIb@E`SPOT>8`7KPK27m^tI`(3s/4;&>VNs#W4*XS3uOe=sb,UcJ1#munS=.j@^7Ti1aaaPE*cnB0/U!(?i2,*pOaVDS1gi2W38hTuu`l;N'(1Om_@r==#$h"5qV.af;.lUCIcodOlT]-bWfe5m>^G%-d@9!0AW;)'DnI))N(EebkG,\HHkO``js3c^^$b7hK/iQR:>f^IoGI_Q7j$N0:`a.q)7X_AZ\B><p)&I=-9<(X)TDM#s2A_8rk/LkHc'g#e$<56g.%:UdDD"Dt>`=QN(_q*H.cpg)kWNcTM8Z2I3Ui.g?\fHAa4NH#Hm)QJ+*61)F1>]8gk?Bngp)Gd0ioIOboLlc`8$&O1&"#JCb?Jnbk9B1eQMLR>(MRA(hIb3g!.L7R#=fr(SbFl5`]eg;t/qV,6,-W>HX%SQ4L7r=Rq/FOaK]:'?B'PF_ri_g+F)_g((O9XOX4lCPUQ1ZjX,_mCZVG(+UWT>%^IsRRc*><1LoU3t'0u/4RT]N/FqA4a8fKS0]?GdIYKJpHktV4m(=Pi;24]pmBfr%>P>BXi75@Mc$a&iOmgsn[)o^l=7H7A+&]#nj9L(H_Fa](OO'Z`mTf?8b5VYJ[2cmoIMUA79g#=iZe$Ys.j*UUh(rE3jRit\S'*0Z2*&CPutJBQeRNPa",0h.S(=VJ[2cmPf6p1!Z$!h!Y]Pi@R]'XY!3\G-'uTa<:<spKf:4Dq*u.U6;k1E,[62B0(!4jlte^=)ejS,Ni'=6oZXWLY)a=4a4NHC>9D%7O/Zuj2d@pH(6RT,"@ZB_MQMsS=V9?c;_Mh9Dd:]3ZX-l:$O&UqI,\sr:`'qB0ZlugE`agCJdIk5V,*l*L3E3^ZO<_Xm08T]H",\uXsc9l[Y]TT`O]+f'sSl2AmnTe_Pjtu;3;6\h(FYD0c4J5E6F+p>_p67N/BCk*DIs5j@Tjr>pCZnd3D*mC`ug^)e82%0R[gTCs6`0_;L2nB.tg\?rWYIW&TE$E<`2t$qA2RLj!Db.aDFdS\a.,c:H44)$S1.+S<aCcn`9oHKW/fXJE-Wo2IFKT9i*A5Zn-laq?+!Q2m[2JV%D='IZVI5afEd[&F+<#o)T+!_'_Y"FPM&#r!hA@$DTLP.b!Q.a<iJBi^0bZXQn&'r'-XR$;4%W&-"oV-+tqRh_^HX;L&2"m#ImEphm"En%N&T9/Bp*9bE!qo;4kn*WBrh1)q]22o9&VsrnN5;qgdj(#?nd9#K<Xj,IY4'-5U,XS<qQk4#4r<62Ip%&"m48PYU2Hg]mLphtEq.9G)gGege]FEn*H:,`ND,-LZ?`;psD'"`+l(mMq/3`Ot5"4L(n@R_-3dq@d=)Y7]j1AR&06H\U[g#f*/hsoW)FCID3Ei+heI]n!fBC3m!nH54hNZW1Fu:Q&U8)5-;\AZp</Q12&Mss<8@l/kCEr$CL;G%5Lo2`FQ#EjM4)nG[,]-q*oc]#:g[V?pA34s7,cW&sOPT\dfgKS+(cE%DWcU=?:;t0BA4)qgKl"i5MG.%2)R%ui=9\Y=-rbnYagOfKknMk#%H.op]F?=Q?bCi4c>Z[VdWi44&$UfJ'5^-bC^4jA-QDWH.f+mY<E,um[Tn452^]IUA0Xin&@=>k2rlu!oF2\=BW(!omb3\iDD1tk*4TG-~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<a53e8620d2bc6cea2bdae9c76a244aa9><a53e8620d2bc6cea2bdae9c76a244aa9>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3500
+%%EOF

--- a/paint_by_numbers/dirt.pdf
+++ b/paint_by_numbers/dirt.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3250
+>>
+stream
+Gat>[:N%5n&]WeA5/dN4,X-=Is3KmEa[n,1-/ls)_-u[5Yms*NI/Pn$Xg`V@WC"A,!)"*g+,e[U%i<F:`bce^ip4@/qK:OV4Dhk5;qtj9T)Q"6'$Bq?_tM-KGH\cR[T$R^598_0hiEgdCal1:O0'K]`3Z#he$%MEs75F3c_%\mT76WJqsi,gj4Eb/n,N4F5JPsErj=n;pQ>f)qsV/q2=f?`^O$B.]R65*[)[st]Z&Mi8pfCj?GhoZZ)&.<n$213^-$=`]1eH(aLT<mO3])[>$`S6e&NNc4?f1>2l^)BYfE!2h/r%m(ht]/ea7]sa'%3c;*q:>b+:WSf%N!N0A3_AE2GEHh)(.&0=e^N1_+MDRHfeWl"NAq@iHp(l,_B9ON*FDoC02XH3rc%Qcb=%fm@kFL33.9Ei6'p4H<r_MmqQ5p5gN,Kfi,+UpIYcP/;Jkl>"E#7,m(;\JiVugM1EhUooG7NhdcmFQYfIOA"X-0TMs9k[dDG@8E<&)Tk%%@7p)ChNDsDqbCE+AK8f(X*Z^gg&cP^NMV>LVWndCoX6!"=O+q5gWgYY1%t/;j+:U7/+d/Z#/*]3ke2)]/\OhYk]PGVHAO9<ot!ICdhR2"on$MIqk3\HXnVHC=eXG-2:,!<6*IV$TpNk.]pEQJVjHWT^!<U.?D]7FH>=(<RI5]6B+:N#aF[`2%A9'P$GF_b-M0&rU":LooX6oI5-@G2hDTb@d<j<bA0LE+bm(gK(@^$\EL3W@h5OQdG1X(CY.7_9QcML!EsIRTOVN!*.a03=0\=U%h"@b3CT\H4&lja'%]eM#=b(:#i@U1G[rrPB&m=2EHn;5)lW)Kdc2q2o$Z+)R!7hc_=DKDhC3'paXI5fk['>R;hE;g3[6th^cJ<)?96>aPgl;'^&m8m0B<>gWlWrW'?E\ZJFQ)WB/I&^Q=28t0!-*iH`3iB8a^+?b\b:>X/s1ju:)<%+?(bu:=4JV.:tM*Olk3T4f,e#L?-fO_p=5i*&m`:gY6"2,=ibB^60X@d`-=\-hNYpFX1S!:?-kZWXlm5_(\Bc[$GAhCoZl-'d(A.7HKT0#kU!g5f3X*X96>koqp^j:+q&^f0'HU0._YNo5VJ6'^%SES]gN\/g1sN2M(\"_]?R"8kR,#s\4Z49<p@"f:$Et8T[u@ccq@n8Y="`)>L+!U)%TDqhL,o_Hl_]_gL[shGOCcDHC6DLS\+Xg10Mt>B0e2u<I4'*JmP;^HC]>8?D]7Fg8>.$R4RQE\jA't<I4&8d*#rcYC1/YQg'*.V^qBp?-qo=60Mmk6E`O)kU!N,YL=54R4d]G\ds+T/EiY2`jaK54%!qS\tbtm@pBek]q^/C$GDe/nZ8)A$GBbIkU!N$YEMt4f=R^Md]E_e6s&UFjorFdpHc!L"hd<)k]O$`V0BT\HCZ\P-*fk@ZNd7mkR,#[\=f2P$GBa^oFfsb^!7O\hXrG`]l]6H]hDMkp#[!8M6,(iN2uT:*ql@+G;Rf15/7P.hQpO_$[S?rkU!g5GOF>&f#qSiYFS[>f=OZDgbiF(A\+Pdl%369/+hPnVXtL(d-Gd>ms8("[FYD)M(Ik]Zc3@_9Gd=^j+:U3$[S?rkU!f,YC1.Xms8%!Fh464k^m,f%A9'/JmLO>oVN8@PA0<BL72%c@F0;!QcVSN.;QamA-&m)'mGKagbj;Km&jud?#s+JQcML!HWm(8A-H7c=I;`\@IBAf?>*He._4]K&=9=^>][4Y/s-=IFr&pI=a4`N!8J2iiRY*1[d-rDf$4>$+q&53b6ul6<EO#e")@QIH;;s1%5mS66*]<r]+3C)?!'14NVdme0!LnYp\4&1=_MTS6+L:i.^r.hh@a+=CTg%?-+X/\PD-M7(?.Aj!4hE$-.hS%>TsPsSLi,6\j4m36=$;nFe(/;-+^t]S2K`h-*lg=dfmBP(\$-oJ@n8cniE!A]qq?0YEc\oTcAJCkjn,Ml\&TA/+d/Z#/*]3kk4(dd*#sRhFlFEJV!$:?EYmO10pU*=Tdl!\ds,#EJ7^G/+bl("6_&BT_HmJs0`i0'mcE.J6o*'oQjf:Qg"jjhAV&RVYd%<3Ao/VA3mEN'mc:Nd!P$.>C)^=d-HerH67Q)hDS+^[bD`(+RaUlnBP1s"U6.YGFbhF]3YZQp(!>CjfGKJA>/F;(?j%Hj0&_%=Y\ObXI?b-"hDng5jiYn`LX@&?JP3'^pSqtE7_Gcf#be`odmV\:JA<)c\f/PebCX.lW(pThLT.JSqXTG%Ue[M("Cr!:hjQV`nE0@T$Q.Q!amV-"h&L(\9X%t6JK%tJ+FM@"h41DPhYl6H>ASBh@a+ElZ<.[d1pZaXS"-2aF[Z0]c_O4X6/,AQqLt@Y*0%#6l5,L?)UD<_625j]0o`U[Bo/dH<0!I\q$.26=0QSKtKeho\*HE=8'JW)pa(2EpmCD\tF98=t_Q@?-qo]/+aHWctd9ZhY"&"4*S;&0@9s:cFfg:kR,#sW@>MK(A'Xnd(A.7HL3S??6Tc'kH&Y."4IFeF4Y_hJ`q\lB3rqXFG4%J]1VO<<p@$DT_&k&ctd!"TU3`O?AC;0(MbA]c"@um\M#Wj=cmpR)D<cu=b1eBhLA=\WJ\</eTbAdaF[]E#>gc/MRrKkJ1d%6T^*":jt]pkf,7W1-*eZF4u!Y9WJ\2\<PW1O!j94?GfsX:>PjP@)O#SgCC^f\LaocSZ@XZl'l<7XLp]oVXE@2>[;p9r[H$?A]t<aT^iX#PgpO@4]"iLWhVY6SA>--=#3C$AX5#aAGY</;XhA$EQfnddF4PU!0d[9JST-s`H<84rf*cYV/Bi7B5aU[9?$d$\0%#Ba:)E70?")>kK=\[d<Hjudi$Gsbf3SR?-*iVVcHa`P5(%djht[%k^Z,oUpNF<U3VSV6qK`D#&'mI)J,]?:qeo[tD^ddim^8QhW%$:UIa2g!8(kWSI"?c3_LT4Vh\iF9p!@')cg&DlO#IOis3j*a=S3ME>]Jd7j#r(PDnl*e*jpHeAde8kdK!i@36%dWL.LJKch;L;1d81r\&<[C&EAr^Z0-3H,)mbkeioBabX7V$`n.7gI/.F!OC%taFbX.^&EBA=2FHnn^FVRpON.e.X>O?saQ4B`-)<X+B\W<pD[p9)W>JHlYLIJON-(A)m.p0@;.GE.k3pcE3K<QA`c^k>ce$WjdhFd$b7o(mEV,S>QfE<q$fCl04c_NrJb-BFdDcmfj3*M,'_UdKjAPaBodcj.`I'rJc&'N.Y.'rmJ%UcalO-]GQURlDR2sr:r==*:a@c~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<b6c79d97e93850e71dedeaee194b3eec><b6c79d97e93850e71dedeaee194b3eec>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4253
+%%EOF

--- a/paint_by_numbers/glass.pdf
+++ b/paint_by_numbers/glass.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2219
+>>
+stream
+Gat=o4)Z)t'SUo4M?2-N/f;;EmOV"Nj#"kYklaM]&_JT",(Di4e_ENpU#@.(".$1dI.tqUI!9bS6aQ%Ra'AWCn7C?l:YW(fREaCOoZq-^o%WF-G(7*6]P][oc`c*)EdQX/,tu\.#+)f`K/+a=mIXueq=fZjO&+NZ_hV%B?Ordon#s3ET-(dqqdhkf]:E9!CT+K9GG?fkrciXnGEC-h<)hZ1k@l_!.Vj1ZOq&trQoAe\9Za+(bLaf%c`<@J:sK6NV0XO:#(L@/FRNN$\p?1Z`ML.0.rD@.er<.QjRZ:*UfGXX&*mh7:U==V>F]^g`_fm>UFN^>Q+FCVM=rP2le8q+3kD0!F\.bHAQUlnA[>TuK<7f+8fj9m?Bs75;VAW*3e^u\Ce6+f[$1brQ_]ofVSQE;S67l\Y-*Si,n.tCX%KWiBlJ2`N/ke4\/82(ALS(k/kO3'Qj/n`E^$XsLUn`p%VLDQ7VV1SdbsGKe<r'cK6L':Xd@Jol]PclL2$-#Wl:(MPGW`4hke.qNuT%N0frroM(>>[(8H8[k@62l=l!ta:8%K7j<S?o"=dnt!gUkaJ]b?f5\5Ib<+`uM.@O&*@dX@K13+(\9q^Li"M/BQ&6EOa("XZ>U/jJ._7ZL.XB@JoBE9R:>JO+@J<J0/q8:(7s7ige0t[T*_bh8g;&DYt(rJo^_bh8g;&D[JAdh1<$qJ:(q$8fe\d5eJ@9c^0"LfY8O7bR!b0Uu'[l9&:@a%0Fo"fY!Ct";cd$3K;Pi4$Ti@'qa.$W[9Pi4$Ti@'qaBN'Y\:kka>b^<Za14<DfS2'\@[)lq%)=(8h.h/$mFaIa:>**[*="W&@^U`nFRPPq;1E;*)*/-0gKejEs1Rs+S*/-0gKejE[c>XKCE)`?q%p!bK&(Z:fTigEi/kaK'X\omYj:&*D3AZ6S)K6<-9VA,r"=b<`TVB7*.N38*1mfCSK*bL6Qp=(BN^A@)<&Bt-G7>>Ig,/$Rl45_-7A]46mZ<0fQ-jc"LQp?V2;kEH5fol(8"frRT`IZW!Crga7A0`0T`IZW!Crga7@OK$Ka&M3%Hc[X%Be]:F>`PZko?&X<eXB-i#Kq&#,H.?!CoQ\8i@,<$4Ss%%6+\(3!p*C$4Ss$%6+\(3!p*Cg,._91uP<G0H\oD5p+^RX+BrD?=]Ai<X!-d3PQdH8D2i$Nf"")C_gt((2ss'E"j(,'GaLZ(2sm%E"j(,'GaNP=hmm:^eq@E5-<(]0!.VVBVU`s96[%\d7PcL]E?.<p(hUH/>-O[J>9?!UTf9DY^iLQJ>08uPH]S4Y^iLQJ>19iNktjXM?WTkD&2b`4j_!BU3$Z62jJbcaqZkJWPn(F)GHg9#+U>N'<#RuJVjXFW+[l9M?Y%8%44Wn?ih&P-;`*?UX3BM'b)M:?%[j@6A)>K*bhk1?a1`"PtW1S-6d#J#q.540X)uk8Jj]a#XCuBT9>!p,E[E^,5dZnp*kj^1U8=!OpF5t-25maCpEI#GnbU>A0q!C,\pIfHn5E2-[#=EF&\;uaVK;b,5W?Kpc46(Etn/B..Y\U#f':S^elLFdH85lZLE7k<O*++O.'`JPZd2McL`+s3?s<hif#>/76A/=`9R'AE)`@$A93L#E/(-,L8/^BUMts^E/'QqL8/^BUMsg/0(Sr!+>(hkg-JYlUS>t[Y>(G!f`Pf)1)?*o-*!?MkUOKmG/d4K].oh/0b^K&1P(E<';ua(JVl0%'k8R]0kLJ%@jY"q3/X5$TOP_?\m)D#<`h%H.jU3TYp)J>Brt;O>-Lh)Ft&C86CEP=nuTl3?2roj*\1g`@B)W*9ud"?GZJh2DDQL1Y3]%'eV3,nFn]/KUTt^C$Y<n9_Pf*La*_1Z;Adp&YZWA)]+d_G0prgBatABF?&Z%B]!=t;<#7?/U$hn/@8ODWa8*%9'L&OT@Cf9:Ft!hF`oLDRMog<FG2Js)/fW<?nLn`U_eaKf3GY8e_r1LRa2b*m+('M)l\/&Pk9GmFDQ9'<I6.CMWAaGBj435B=k-+2lRR+ZkE+FOorr=@m9AE35O*TrkIPh9,?J;9;#P_;kt^-N\M*o!\JT@i\tPN3FIa26*c+!Db8uZclG3\.9QKj,#?uP"POJ/"<=_8t(Yi%E"4'3\o*MraiBgSbB_u:6\?nI=ei2Q&'C#58rGB."2Wuea?DgR^&%.7!^WY0.h=YO4Ma\YOoih;]X'poNQ[S;=f.QX]>P%QklXIL%+$F\['E~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<15b9dd6edeaf6359c3a98cbe95007eb1><15b9dd6edeaf6359c3a98cbe95007eb1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3222
+%%EOF

--- a/paint_by_numbers/gold_ingot.pdf
+++ b/paint_by_numbers/gold_ingot.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2805
+>>
+stream
+Gat=p9lD>c&r-/P.pBNR$ObG_B\P[3EbBuc@)L6Hh$Clj.gQd!&q?P=V!GEaBY1:]819AP4RKT7H;;aG8c5mB5QCZ]T71.5]8,LKHb]?[4T)M[jO3Vgh=C*ph=KgI'%6=G:gIq1pF!h5i:c6t;X3EBT(h@*pZ:;iJ,8R&BmKRIe$$rUT73Vth_3mbn_;C5[niXrq#;/R_uH$X0+X0!QG;:Yc_qr"H$:m9*`q*%4tlW:Gb87IlaE%#F#E$icp`")^9eFMHsHYt6mJgS03Jt5hJFQ=9sc5`[\-0G27l$<?5!ciO)'cEkS@F%;6p:s,e"Ff'A\SiZ"Q$<L=J_r\UI6%LHT</+Qgr1]PBDJf'6_eRKXu*h&<#""&b)\XK,q8d[$GAX&.APU[r3GMR"_+>ZO;c/?>:/=VXddX!5\t<CFC!MC=fkNcJ8;8M7%fb%4R@\ZBfcAQ;./XGZ4E<^g(df"ARn8G%eFb#+C'NcJ:AA1O]#79S_#asonY<]Q&CMG]U<:84gV[!QnTFF/J]Kt`::chll1BAYiPpVf$uBe)f8q[AB+&9"WZJK2W?aAEu[\Ut`N=BsOgW#5XsMBS(V49T-!%=oM<&BI]WJK2W?#goe,JSoBXa8Mk$I#Rqk?/!6\\WJe&Y\D+rGT!`mE@L8/'T6*NE&!862[kGg^r8!&\<o_fQ]<>&5MLoN\RKR4jN:>k>^:9B\XoC?q!'`#.n;>)Eg.qQ9X`%XUAa#smB%g8@mY:E/*1Mb0]iQlm6q?I539Wf"tjath!5X^Ii,EZ8'd.sJ*=Gf+(Hr$@DK`%'.j&ii5-QL0)T/9_B0FDr*eNh5K;@<%m;huM9mr3=j*7M`4:P;jB6-KCjU+MdJ1egOeVd^.B0o/#J.*]FbRJPEF1D`Kj.TEl^k!/;e$U0*aQuMc`hA[J_Q^HF2PEW/6k0<kJh<#=h*h2$'q,p_8:I2/j%CpD9a)Afm+>aS2\9io.4-+Do-)K=h&G-KZhZIE7oMH/=^@g2Wp'T!m\,kkt%i3?F:s4E_etNX9V&Rh3At809Y/(I([!,2_%7qFOJ2[c2Y-aChhn69lIPr^nq;gg[p4>YAJ$iZ:u_!AlCi/2P"hr;ZiA'3oe)S#4?3S)&>+f@+hD5/o7QN_PRu!Chgbk9kRS\eA,XbcFC*XJ]fsBEFDcJpU'0qL7:p1=P.`8KhW"][cq<A?rI/n:*f5c<?#g%h:.pO>AG:ojEml_N@o/UCSkD?([CCu@A$p/([CCugU2>:=K&^LNmt,m2YBhT:p5EXohN"nYCXm^SRA-t!uC0mE1pT$\#FSqKmF21W-;LPVHs?@lCDmf?3;#/ST(9/"..P"hVG&84gq?!kN7>A%:#iUll;tUJ;&;rlq"f53Vr_WoDV<[D[c'\i68h</BljW8)cC6+l3\jpm0MsKm,WD2UJTJgU'%ICpU8F$gWhXOKJW-dN.cWS84e7\RR1TX2d-[%^@^jJI:EIGI@h0J;%r(C`3$!J;%o'C`_fkJ7[OHWQhktC:!:E$eZH&OR5k#E34Zuf65Z+C00jr%%;CFRVMdn6a9t2NR_9Li52lbG9gAp(UEG="5=`uYjH\G9t,Fddr!F5"5b$,n86M-#/W6:=h*MJD8nG@@GIGY#0PJ;RrWjn^36X[$g19hOKO-Bkt\amY(6uH::SZRJ]lafT3Cih*o"=h*k!D%!uKsfE7ql./BljY#O5#pGO)\OhPl-R;_9hJn`lZ+W7Smtp"jZ2[<aE0<ppLl>.k\&X7lf[:p5EXohLe\oiel,hT>IX]b^%8hA^:F<j)\MlCDot]`p+=45mJk/Qc'B%*RqDE*9l<;hKBJ>ZU<h]hkndH`D:AKmF21W:u%9Y17=HZ?g0=;nWgP\*<]7j!=O^:L<<@e'[tRrBUJe(3]&Ljk>`@.cf5\7rhR=Ri?_@aGkKse2Z<;VFE_7c.GrbB%0a&`X*Di<+DC6a*Re>lD`.iKF0<rZ*7\u9`lp2Z&mrJ$RtAGm)1Wd3DhP%Z^dCnDi$6$[[=2dQ5kU:K]o7kW"Wt%07RegARrTn7Qn0gCo$5P*VJ4(%lIM"nBkd[n<&:F6CM:*,QefOlFCV:,X&UcC!;9o$s5K'Jq]E,Si>!:;7JuP2Bg.=(dX1f''/;2'6kZ--cf.E6&tN'$d$RHpH*d7Y28tlA$5"'0qWD>jp!HX]]Z0.QlEOtjqB;c>Wdg#\RH8j-mp`VEYS*k7kn@[[*=pW`I,d)ShIY24C;3s4C<soc^,i%cBk'>a=*cF"c=]E>7ou&.\^0K3Qbo5,e:"6.$mpGjb+UBSJ4pRX!2kU<RDPGQ#BGq<]Q&Cb#'dlQu$?!UF</_79S_#asonY<\]K;b"7gtNhWUq'P/#SXfQOWAX0#q<Zub_nu");o:NIag0X_l$a_o0(INFm9Cf^8c]:jd5JHS--LV.g5/ZKqdeA_/4idiBQ,Tlt9a<g!rU]X*XK9t"+=-fBMm70-I6]<rqss[^)"^8qg1Wui7<Bdh`c'eL?iG0a12Uj:3;:(?Ydf"\+tkS8X5ENl+p-R<4jcrA>=@,,o-K-\70Hf4rRW-3qYFe9k71>K922c<Kt_e]=[_&Fo6q-e>=:%*0CJIjLrU]'gi(qq^PK8I9$\-?hf>Q5G3cE!q!'i[$+.jd^$RerSfI.lb:4.,JtA=Y[=>(:(MlQ(0(3/<`1*ojPIS1&G3m*ErJ-GL^C)o_HFCd5RmEpGB4P`JY>4(OMnhp>/0`Oe55]'>52PqJ*t;=c6E%#O(3-G;+%O/)I+qM_o@HL)T=iT%543XOD`:1+r-PjMDn0K7rr/AZAc(`,m[D>2^B*P9TFV~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<0e5f7785edb542cd156e7a2474bac76b><0e5f7785edb542cd156e7a2474bac76b>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3808
+%%EOF

--- a/paint_by_numbers/grass_block_top.pdf
+++ b/paint_by_numbers/grass_block_top.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123129+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123129+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 5340
+>>
+stream
+Gat=q991+&&OuNo'b+];(bjEd2nb]C-#\r@U/cAgUH$?4!LuUXITV"OMu8C6M_5JK;](J=X^SJ1(YK>PD6M3Us8V?@g\1Vlqu%nS=grhYgLc'EgZLe;+$Y6rIc"upd.c@)NrFJ(6s/bKfupY^,8scaffoF_qs>K?r9NZ%gFlo_qYTuQ07U0TrdOb7f.[1&n+Qaas8;N8hef"cZ$lV;81&6Sqdr&qJ,8])B,h/)>VYL=Btr..8]J;(DL%<*E9Z#F1FZt+q]C:c])<KJF4#4Sm?[&kA5`nL@!;>3b4YFO.QOK<+e!cu%_;!mE3^hQE2^S:0S+HK%N`GV0J5C$[od-m9+s5afBpZo=0)VmX>bndq)-gT7./0t^cn/O;[L8P_9j-EGh&='Yo&tn&PgEl_3>kCML/HH6p&YMO:ba'8Ns3;K\qE=m[,6=al_Ds]N#DoGM1L+.8JZMge\OKi`(!9LLTPb1!PQb,</,U;Gk[FT:LhD9QME;na)=Spj*@J^a0o^kC=RlK=,<pZVn[M2OdU*]*XFOF7A&II94[M&9\^;Glm#7(Lf/B\JC>eod?Xt&b2f0';r`LX-@_L`:ZXdf9WFn!ibboVe[#_^eMcJSdmh_Ym/u_N"P5G'l1<R`Q13F<NH2,M@j*r<NH3['a$G_f.,@%T.5:-E)X#rgJj+4gM7NS^oV"8D!=j:)K&J.#4/KmX8t6p,M6A(=9EFj`f]cB.b9-B.L,<?=g<i!>ZUAF:U#^6i20tR`V*3K)K&J.VCi-(::ghC(?l_P=2Q&d5IjWFZ%C.G*k:g@K12m"ZA?PGe$XrGf]%ld.08!+(;>js(*5u^#ng9XCIYVa$ZNeP?j3tc`0US)5nL8P>19b>k[%\#^\>"Ik+bgo-J3,0.]>3D_3Kfo'@a(ueniu%iC$4gGSSl"NdQ)A#?fEV!o((DNe%qHHQO2A3iYhl+rl2U'j,YI34A^lEY[5qO&-hAKH^]RB9Q!\.cH+]8&IR"8*hiF<rlpn!n[k&<Ie5_,C!D.Z#^XbY'kjOe\:doh7>9QP'.RJY'hJQ,)B;$DRJrS9u8fAL<HtXN.`#.HQV$Yh[qEi^'ZLE^(>5p"KVTEm0fnOJq=_FY'j[$i\"XC\4IN,3!pG8cgA+n9XZ'g=93"E_asQ<&M(@rqn>$N\r(@+IQac)`Usa!Yl'l);XpdfZ\ec'";NH&GrOt9!PuW*KEB=DIM$KWnU5@80n>Hq@Ki,n%,`\(=93:cnAt9SL_X#-nZ.4K&`3h;&HhfS5?Pg7&Hc+e&(Z86`$75JqnX1)Mg,@pBbNf6DB^.4DAP]gTA)dC?n7%8!Np,sC^dKo0md#RAIlZY$erM&3)e-/7HNKV2n>LpY0&6fYQi;m*l6--HWUC4Or2!d=6;>E(@fJ:G3E&H$?-e9">!fGdstT>,<,rTYm/uU@[Ifq8Z^mVM.%[h[>>XVDISFsH:L<>AJ;fq#r]$mb^0sI=P+)6E*:+(GHTnoLc+*;iYMh?Mcdg_q\&HbY_P)@/r1\/F=CZ.QZjcaJ-?I]@WM&6DNK*h39I!]$l?'A8DV/jE:Yc8L!+KTE:Yc8bI**?gpS43>bN3>E*:)oS_)o'@0O/T(r8MbYQFaP0Q<r'T<;T+[qQ[L==At?@,;[=.<035"h%PN#Jpf`<e+C;$t(a<_]!LC0M[HMBNP:aC)FLur=KAhf>BSdP(se1k$\B7f,dt3>="3h==T+o2Z&V9pIE/(9i(2g!jd[t?l&8<NkujB#0\84_;8LV=M\hX0lW=eiqm+be$94I`A#5^L_X/10ar^K7'$AI&Hc+eRF#p-eN!Uk_8H#X>Rodn]AAq%E8(OWi+BgC$8-]#`M([BX8oS^@=Y1p=93:\INaR9iVVEu@2K=0jp2E`4U_o1ors%k*X51q_8@mm>%amRNelO01?-7ZWG>VPAIT/T-eo]8iO8.4OXh-`$7\,^TR'2GpURsS*k9YTY_L=.*_09]Kb`D+f'nL?Jq"M7/qh8YKc>^\h!X&SC[kTC$7sfFnmpt\<H)*U"#igF<H-X*j!59rKf.X4h[qBo,,)eqpC>t$Q,!_ZX*<V3'sIb_jrGhQZkK]KPJ'oN,SBEMX-<MQU1uWj!mKdI_+?,,'jrYE8$KbB0hoPsq8,Zj_7oZ[h7b+YIR8VYWrTJT8$J1,?j4&?^bEXBrFm0&)]7_U/h$KY\18D:-gV*h\Er.9CP<^\2.2_(J>Fi+"dgkM6gOpb/&4ls0\;KGiVVEu@@1k.&?u;\,)3uf?CP'5AJ;sP#WE$E>YL\RWgb9NO_adQo4>2\<3-*Z'a$E$O3MCS9uR+(:EE:HCUd*X3"k=V`<n<"(r5_V$;JJXE4\g]^r!K>%JORG*!kNWS;,clN)N'Q>tk?3'*HnM9+u*Nc,@[dY"btu2\Y3k(/1e12\Q9q\i?Sg5>@*9'6YT7>eW1Q6[UIp%C_2hPpMlT2;BP<<s-i=r;;(,*e$;d*)\KDVKf@Af/7pt)\02Yk7B.KR8[MH_'=,L&ss\e+3P!4Yt:mKmrQ*l8+(aT1)p!PQN\ofXUFnf[eY-Cc;tV2^\>"7?PirT0DI`?g\8\NZ@21O=hZPDU!*0oQe`$j2[f&ecXld0>[IX,hWHfg!`h)FD(M$h3"/A4msQgH(QRJ??!mi%]aL$?(VJM^eeGoB.das'X#hlEGnj^>J4K*6Vm:Xa@$^6eT%=$<^'ZLI(BWFsqq_R%r;p)G=BP`DHP)W,8\b[P1GEdM?sj/)'g.)#YSWu5G6bn(*BRB>AI6*gi@\OBQnA4c@(*9@bShP=8[pE?"0Q>EC%?qQiVV9q@5s^6i*ceV76H18:]W)VCuSN&@hZ<pd?rQ%j-.*fP1iX3!-8`7Js.<d"d_Y?Ep%*6RYV\`(,9c^gOp="/n,Y'iL68@bT\+EdZ\_jE"hc".FCSci3J.>HjCq1&+1V__;T]==Mn\^"';LW(#X8)n;DpoHW\*q&&SZC_8?V!X+t,`AO49/\U>i7"A:fg$>t2qj2D#)L)!hA0M!BpCR>?1Tj_;kTb"Y8K<p7hgf=rHg`Tjjdr:e18$9UUBMO1s&dGGA)m%u'K7OuF's-@P"cln9]XLDKIGP_o@YI-N6Z)gVaWTpQ/%DZf(klc&C9Yss,?B+[6c3b@n1/C?YD1fm$XDZHBc?Eg]q>SgemJZICLB+KKI>k<gf=JD][nf3dpSYk+^C]@k4EB3>E>_2ce#@F@.c"bXPOOO4iPt-WrTUjdK"[nS=Bf,mN&S(:*n*X5.JcPiY<N]d"'f`,?VN-63D-%Kde2?=+Or__MjQZHlq,I$j1MJjp2E_%1E7F)\EuB.i>.:'-+(RZ\(cPFAmhsr7m+D&JcX>+3X=1Nj'X7"h3$s0-%e@<a](I&FO5jpW)$ImJ/[#lJp's))k:eCqOhM>MT5Ip#iNnr:TCM1[F%[aX/(@05d9V?[mfo^j_[9lqkH,]KbE's%n3KpMZ[B7';#RN3*S5NMoU`qSW48XREXUPX''kc9tmqH(4[eLjHda]\RWX#T#j6J9qMe\/N9tW'Lud^:(R:KCJE0VmbE`"l](E.J>J%:I1LX&4HK1Ws\#2do"F0eX1LI/>^7L?ttjs005kUm*s$'P,ldkZHYPp@jqc1#=K.QMGM_EMHIh5[^jG3/4IA]JLFEUipEBC;</tO+.2pS,OHJZQBD)mgWXq_S"f\/g)*7LorB,O;a4i(-&S:V0oD_qOjC3cMJVT]+`;?cARm*ESrkab;PSJ4e8Qu(8&T94Vi8PtPLhVd@RedP/'e(*>d2[b,\h:s3ZDkR2"sp@<l4&LJM>09oe4mN`]38P^Wl_APEdhJ:*9tNB<fr/N&hOPN<8fP;X/k2K_k)DU]`nE:JUnjolFtp-@*hZWLo?Z&k5Y(KL#Z&4>i3)q3$trrKNP30R?V>$o7%9UPA1DnPn)d9c9pG2S'90/Kla7Za`"_3;*)u)ME(ZF%8B_:ApE=Kd_72+Gs*i+/sh$lKHjRBC;[F/4@n7!E"qBhqtA`\=P(RWLkroeqIlgfq6RqT4*gGF/4Ps@]pldc2EliPq[MZ`\8D.o,N^5(lasc><dT%VjsiAd?=W?O?`>,C1*!HY,\>qgga7K;/-s!Y9h.'B6%9N4VuWoY(IXO`\SK2O%EI]K9LmqO?]eqCP1$-:ShV&p6_)@0K:Ku`p$8l%Ar>a<Rs)&;c;lf[912R.^:k&rbs+DjII1t#+\D$-%PrYPEdPB:<"^'TZ9Q;0G_+"L?baSlDKlJ7+"pg7R751+/j`VT*pg]T/%%S.C@:'QBD$ejKQ+/R5Kp6Sf/"A*>c(,_1#"u8f0];&-aTU/Q.5KfZUO$K2;H1PEdhJ:<"tM.J,c$_l5pXEguqT.;d+J/LfZSON1j,S*%^$eA,?hEDds?rKNP30R?V>$rUd<5Rln2YLVJfpJXsj_WXRB0M%mUJJs43>bXskPS@cT;,74N8TCGi0]@:M$n:i9r5'mt9=!=-:J"[qUF-5^+G[[XC:If%D!=XlPa%FeH;YjoP3@7i#%:@,9r!7;Pa">\0^Rfi`9qo\_3HSJ@Aeimq6L]hDT^$m$p>gH_mtRVeF7."<8ph@ARm*GSe27gX?t6ti(uQ0;l1TlEb'6]&mWRMWQWla,n5pI'Ieu"C:I0BNh?^]HVDR[(n;9KK,"/oWPSK@AZ'[mfO778@c32Q%-5b/:Xj=i?]RmmbroYan"sR\@aUIerHGt\6Y@'.%JNjD)[Kr/ku`godt'6Dok1"RRjqBVDKCjV=UKd;Jmja'O&+8EM+"uGgY?:.U,V`ih;T>:-Bl^Yf&QIL3^u;1K@+qf9'@rR9/1BT0Es;qnUVUE3d"^tMcK*u,>2Ha7PG76BDG(-L>j=[DKA$J/kIo/9%;SVP!TuHp\%D<;&G-.AqUp#gY>R@9NK$o(JMh&,0BH3)LoXlos(&Cp!Y4NPq`%\'+!XR!^0VeGi^9a8BJYr3k6&JS8[:fh!02la*V(5V_HCR4C549*$A0ES_mMc)"tP\0[BOd4JdTcHsN5n3AL3Uq0aQJ@C'_XK+sbuC:JM;<*E3bD0D>bLD1NU-KiA!G/2*rTg)Ak"1D5FA8pn5c*!<c]"T9q;J:p:n;>q@%i5%VZYLkGXtL(@g]uZ7iF\F_OY.8SO%K/m5(9cUh6-5ALEAJ+ds.B_.#c4?p^cu#p;rh\l'"ncSmT"FoiM`!4_A.T&5EB5P"p;je1d!)hSI];\a\0P\n&I>$?t?u&KYLj3pl11iHk0:)/\Z:bcJb1'8(:d52Q])e0k4$bh,Wm=UCfM"bSerRAf)$p$qQN5:%W*JC[fjhh>`k%,O5;kG,,k;o<b"_qn<VAS!<PSe_aq]S>LH@1>g6a>WckAsNM_WPLjF.eEs\6Qk,Brs-LN6D4~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<0b92ee328dbb4af35b4b6c57efb66eb1><0b92ee328dbb4af35b4b6c57efb66eb1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+6343
+%%EOF

--- a/paint_by_numbers/iron_ingot.pdf
+++ b/paint_by_numbers/iron_ingot.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2737
+>>
+stream
+Gat=p991&M'SZ;W'd^,9/<!qI]<Yqb6]kaYZXO`e&;8+mMNIW1\2nbn>ts#HhFUB)dHJg+0%[X@^Ll1O[U.bVs5-!kbJWB2p%N?DIX1j$ERD_dn]0b'a&fb=qo-VSqnAHG^@)Pbo@YD$PpMdI\1MR@j+la>TAKPFoXm<$qsD_kf6;_qYMUmL5CIochEJ^Sps3$bj'U!ilQ'Nejkj/5LAL_$=3!)=IVYEEa,N58c6_Ma?'fA/;g^'QpEo"gEr4kFe+1['%<[q?:6K:2B$ISOU*U_mH9p!6A2_1_8^u@%ZmeP?X#I`qaThM[buV*4kZ1JbaH?u<hO<@J[i_>'gZBe$&CP;kg*@UK8hhJ9aTA2X`qgh2J/Em[ek.hCY0"bn$=upX(`0Y,.'"I_AJIUoZLUSO<=l"4$DLL#6'TMALf.CO.$[eoUp:?%<)u;Lb0!4O<^Dtm.Yo-W'm'Uj:"I6f75$&>+%9?..$^&l[^,I$Pa.<(XF(^njeF4S)b!p*,g+7t]6i^;&'rpnld+(ekM5IMfl_MSIBaO>\eVc/D2-"@YQra6J<+.Fpa?RPha%Z:a<kh@O:2.3`=VN9)?MhML4G=o#l#g&J<+.FQtY(e?OtKFrV0hW/qiVd/o>(Yge]r)@cNE*nPWc\`^RYE;_2NX_8Ru!>X'&p"W,'9iF3]?gj2S%EbB2J@GBkK`G(OZ7qm#>_853DqW,O/-^e4'MTOtT1q@G.9eI+H#H&W7NM/8M#?,gm?O[Lb>f!OhOhKSJ>W>$cXW&)A;o'=er_R"]O.PYBrfD2j5C.4[p4i\WIn[*9LOon`9XsSIJd['%\F>9*9E#d#[H7u[2V'Z^L\\(^G@#l;fXZZOpfSutXID.'f(%^1_aXG=;IVB3q0H;sRU!OM0g.4SL7>;:AW'LTTeR""$RV[6Alq#g_/7K`\c1<.)D7Q3F5s\"1gG(X"A@%h@,\a)Q^ju32Wp(1j?*kecC84`GoA<*2rTqk1gE"Y_BnAZ\E(:W(=#idS+FWe!U"1,oop0"hR2=fV2$/seq5*oAo\6r(WfE*+0R#E[?`#'HD^F<Rf@:RfMo[5S"@.U^nqGkg%<4Bf/?W:aef_fZ`0H&S'JOJWIdc$ST/(:"o#7c$k&OSY[l3#(H.P"@FGN!2H=/,VDBc>Wo0%7B3a(g_'PSr\?MraHe<Eq_p,'!/8RB-_PRYmflXM/Yc.\.cUcjh>oV(PDX*57fTLtBq-L(FXZ*HlCSkDA([CCuI\:!N([CCula;$R=K&^LNmoTB2YBhT:p5HYohN"nYC]F4SRA-t"W$BoE1pSu\#FSqKmFJ9W-;LPVHsEBlCDmf?3M/1ST(9/"dd_#hVG&83OYork74)rCUd40fJud3!Xn\pfJHF.O/>*)QFq^qe/Q'R2)mCq!XnUCfTCCn=GV0[-1<=^n8:a%#MPGQRs$m[aLV^0X?4Eg\dBu[GJ"0"Y(@#DNj2E`*8?]>`59"k.Z?IEfd9r-(;fICH/Mm1(;B1?@A$g.Q?53a2VZBRc*kMQBX1WG+kr\$i*$:!Y3i/4eQQU+n</"#RVJCq6Xd1Tc"jI^E8fNB4-H^t$e\:bA6T3Q[N/kIDWTZNgRc"eI&l2B[hCBIX5K.[HgKrnXo]!kp=qc,Y+472gN19?Etqe:GCkNj'jO:R_M*+I>Zc3eKm"29ddD?.RWmlGk1p=[i`0q@h?fOmX2)Tb4a*LTQoAO,<Urm*e/M&`6Plo^%u,Bf>Z1$IS$1ACiKAL_ghZRtYb^+^(@"n=U#$H,n5*3(-1t$A([BOi&+uNuiEEo5/?*j5-1rat;"''1lIB96]e_4==2Q?W:0IkpC:L(r)4/jRi?%9TPRQhW@%lEj2dNIc_^5!$\;,AjCi@e_8&e-qELshmA#cHPV<KWG.'TpcO3Q:"PZ&aGSiW%0(u*iu@n1F$A"gp4*],asZ"1kG3\mJ#$8G;[&>L)s]K"aMGYq4i(+3'p;3$>FHYaU&;3$>E-Wio:N[6'5WQg9i3L]'^,^G<5&[XuCJ[bD&>f9#`AQ1a"_fkik"!f)p(,kH_H!hjW\*9jS%XtBK_hF-ul\1B6>S9qq/H[.FYV8u$9`lW^\P5Y*/sN0I_FYClSAb-6H%qBs*Gi(hJWIYRI$Bl2:G85'$P>@LO2;3NPfB4b?B2SNl50HbSaSK!Ec)if#o@*Si*soWDAnJEJkKT;_.(XA'@A.nNFEb#,j(#G@_VUck)55-q;S0:00W#"`RgUA$Z"nf9+[rq&k%fVifb2s6'S63&>`hDU/Y/ZPfh-=WN:[sPuSBlZ3m=ji1m67+A-2[7$"V\\q769i<dZL7o<;N8nDRtXfQmaA`][8.j%2_q'aD.7T!2MM6c\LPa.<(XDG8/Q&hZ@I$Ddr,Tf4"["Z,?Zph+aeONi:borS7rTCX8IscSBo_eU8S*k1b@IWe)ohMn?T9oH@:[_)c@Z.4<&F4O6#\>UTMn7>lf>m&ae0!u-<d1@BW1K.j`a@Z<=h\"QgFqCB9Nk)gO,`V3Di=,XaQaG`pp*?`2&_g65:sb(7=8&-9>?9"ZX('%rqa'ZYSQ8hoe0N;aN#CjoSWut&_ZW>IM(\On[n,Yl)7@UF'7(\SIWD';f)6AMHEsMD:pSu.bl)[g\hrE-?fE2Rqo^^mr/7&,PO*_(mb'boCfq4("iN7.T0P@=SGJ'MUcU`ecsu:hsEXRnR_TiO1uRG4V=it."8r'WsE^[h<"Y4mYneh(%$tPX!mjEQMo76@X7VgF<mPI~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<d3abb401b82e0cca9f34a3882d864d37><d3abb401b82e0cca9f34a3882d864d37>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3740
+%%EOF

--- a/paint_by_numbers/iron_sword.pdf
+++ b/paint_by_numbers/iron_sword.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2636
+>>
+stream
+Gat=o9lCt0&;KZQ'a/hsF("hBOeYdO.$.aRT6`:+2aPhNJ1p`qSQ0if>_1ZJaoWbSGkCDTa_+YKZW7rgfZV#O^FFC+W.'/-Q$)B^+(^'7lLDQ6GeCZ$mZ\+6l`TI"?FP97F[itWMom>\>>nO_?e*JP55k6RU0aETISkSZI=^;5W]sh)]r2J!^V,*m76UXN*oCd"3i_Xmjq@@=mrs*rANO)GBg:7.Z8QF[9N9\5?!Jl%3Lt3!\c)*qX?LI!LFR(7&i<`3F!q[."RVosONo+W?*t<p_)[tF-"qDS'e^F)Q\2FP.m[t%a_/]qGaN&\--,brkusWg!.9YbV(*>_?]+P#8I>aSC?%E@!8Sh/E-ea/@"MhWgD%P:&_h2s6E^&D)oI_;T*p9K/B"+@`hXoEd)X#=L$IZ#/3/oOf/D,(E(5AP1BMZBL*t(\!K,/.:io0WU,)ibS`*Ff7R3\(!Yh1;T]cf>Ft:bRl%K7o<3&@e+U76IrE>"'^CIelm+4i^qK8+9qm@&pIN;nr`33]naDctMpr0#h(QY:t/D9s\;=]W8aY+\]^Nc"@@Su]S-cn"_-,1;(QNg2<(LQ,a0[\G]UhMG6`1i/qWgfq8:MhS)Z!h,$67eNaY80Q380nk[e<u(UlWg3OGfZZ@+ci@Q/D3/H;=]f=a[7*q%saC%A5VoZ-cn^[m4Ek;ZR07K6@spWlc:]AFs33Jm;q+%g4`e=[Z:k2D<8#sgNg?SgP&o'[a4VVEHr?k7LNQ-D6X]kH'Dk#;3[1hRuBI%1@cj8aJ1"*O-5GQ8hr/4^LH0oJueA^k;CJ+*Z7H00'&2+IBK',]9#\Jp:4U@mQrOpgW.<j\anBbDP-5Bk->Xo1@d&jN3PDaJuJeh"XqMA5^+)kP%59".&-c2)$MG2-pUX!%dfSuS6q<GOXD$A1\B%V@_90$Z"._olc/(ijH@'%DA\kTP"Xs2\T)HR8hQRea83'Oqui4B!d'c+hu_#fWm8^Z[P.k5aiL.RL2Ah0Po<WG"_QEs2il>@L"P[u:FVjR2U0o2CRXiCC!NKL\bsAcN.oC.@%<`(o`TOmon5\M*;>,?=R6?LfJ)Or$b=n'cH;uTY`Oc+iK3@Q4b90_juJKck<+Wno1"o++_t#>AD:+7P3367oK:!Wkfr6'cPL'4o0,',4I>4l(cW1V4tF*""a7gf;ckFK7bQC6=ogLBKii(4I;YQ3&:&//+FS,E2ir_qC*<+g>6A$LV$>B2qFLct-b/gP(2Z3c8#[m*./!f#?KqhLB_[f7fd[c1e.['@2.t"(k2,@i-tcV&H#0h"Mp2pW(Lgh*Z@gJ1II(rf[>(msM[c@QNK\gqO@oIZ4pKLHjKYg-9WP"-Y`MK5?okTq)6aLRq9>\q2iBT/H'J6h;=p@0Mu5J6BC@*MciTI0k#(c?+btMN"09h.[T/gTo%YR:T0"iV+dWU%aX+nBE`)?j2GG/uLaC+=gt=PlT%bOZF8aa3G24urH'HP7;)4J,S%1XRk40phbDV#8L0V-C;6jO\5g`g;\spm,,U8))A.0d%.ef^/?'91R(M,_iVQl(1\\!f5je@\aYpeWUf8jM(B*/#EOQ`#27DAsRqSf5jQN0Ih"R,9?@!RrCqca2LYpA#AOsnpB34^So'QgeJa%g(]?PV\-c,2`R:-=c]P(nDOjC@XF/6^](c7G3XP(Y3f,b[2`/r1lb5f.OLVYSAtUao*$XW6#)AP$p-,uI[n'f$N1"fh,A\]US?IB2a2e&KunE0/:MLoj_4i6j@2RYfei?t[/*[cXXKfi==YZY&Pj%B+)MJtFI'&51<?jH?k?ga;DsaMuX\`8Z!kPB*/PlpN\NH'BRed:PD"P3+laT(>R;kZEYV*>c-XE1mfN_Y):c\!!^@/EDP[NJ4mK>\YDi\^WtBgcB<r$aJ2J%cpI"1ipK];rCMf$9UqTo-h."+,&co57!G\mQrJ8HP0!>Z=hbDj\^&b7@UnO9()6u]$$8t0%IVmY-//-(k(`pF]W$Lh**`Vc!?/pF8K'('UMJ[<"u"(U&[Us"XpB!5Z'rk7Cr[J$6qf5(]fKsO4'1,TI>a!h1ah0-4HL&MD-`2`oPM_>;Kk7Q]*rH-"Rj48XYcIFG>Y>S`*FdL.B?'*[PHDPal/ZEeYs`)'1):Ga+_,dH1juOu#4XcL;3W]Aq@Hme?p37X'6C<'G*dglK2V]mp%Zr:9+JD7AqFGElp0i$YSkkL\#bAPLRF=FaJg`tD&B"Y.38ZemYJDsD+j&V5gI8cY_m1#Aq&_W@[Gc>N986TR2fb?]3K*R_p"D>*C:8-aotGPUKAFu:!]\#AWU9+a?'D67fe(#ec`^Hq`@4;7h"_4rY-LM5VHiq;n_n=]r7KlI"(C%,C;\er3>>67g[5AZCpMA!4O<F%g2kMrEhBKco+7&]+SZ9A%6i59..IBK3''67"d1a.W(&lb"]\&[GKkY`Dm`p;fg)8X%3gPk4l^[>J.C'I\fZp"78>Y-Qcd@IZ_)O33b&cR)GDQ0AT87+g=XK4V=GaK),9CPQ#Z]0Rb>;7:.cc@\<Zl/,/W8!8qn6cd-1]$G^N'T/3\ughqdqGpt,\C>W.lYaE1-1b\gJC^9W@>IY0:Hk4<8dV1K<X_d>G&*sjH_RTPT7iu3i+A#_=[%lh>Ij&aX2K~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<21b67e6a40ce9dc73278f56c99a90950><21b67e6a40ce9dc73278f56c99a90950>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3639
+%%EOF

--- a/paint_by_numbers/netherite_ingot.pdf
+++ b/paint_by_numbers/netherite_ingot.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2967
+>>
+stream
+Gat=p9ogP['h.lq.md\IZS:?V]6@1:J<0sN:b-^kU$)\8NRV^"^X%h,Gh7s$m,qG+daX%iSTNT[SVkX]9"XK_YC6B<:HrdPe+<:fhqQDemJ.in%45o;5An5_IeW\e\%-I*h\B)Dp[*g9`OJmjQ:j'CVReqj]`%\&+92<1Ac)&gVpF,T5(9BThf"!nq=aXGlT`.tCk)BRks+'SZT\>(HiEG`RCN4ih>W</b9,T39.@n5<g1fJr3BIpN,s@$nfCMFWGKkJPdAX%PHQXo?]V.`Q.DI+U</jk6Wo83?sId]8[g'G?*u1[8,%"!IO,o'EQ,+tJBPc._QH:B2Tb-I%Ie6ohQGYJ&'i\i<]7akBMti\)rO@D5,=GI"Dc9Mr5o3HmnM[5Pmn!RRC0.`=]=k1L7/n#\e*u//k"$kb"7h?+j+A%LiQW7U0Q9'.$mqoE`j3A>h4TWQZXIoAX0#=lU$iZ\e%$J]$M1V2=2`$P5R^MjXA8$8%G^1ZB\FMU9&ALAX0#=WuOQ2`@/kY-W*nfgAQd"FSG-n1AqWPT!bc:Tl'N3\1b8l93[O:Y;7_a5eLTD#imCg5`YCHa;r21phXu1IUrfG.#(!IndpW!2?\%76QelR"EG2D+@NiM34aH`542cK`d2!1lI%"kSa0uG#TIA\N0aT=)])b=;_2NX_8Ru!>W3Kh"W,'9iF3]?>WS%0lkSh>fJ^9LESBKr;4_$<E%nhg*eDsQ=!h"/@WLQY:Tg($P:K&u_4eKM#>^>!hU&Fd]>;=N/%Dr&g$Nq)KbG/*g,Mlh#A7066\0qUH>XSpA"DBP1$6=p$7u,&A)k?H$8262iPHZD0)X+<8,c>(fcO^?o>`mMd#$+'5IBCc99>,mQ]R1hlR\N-SI'ke8!],KmI$;M`U)1'rRuIZaa5tq"#FZ$GrM_P0]elEdpT485,C*R_KcK+F'd0%pWh6,iOfJ`SYtGPo6P5cGFf!HkOmVPmlUc_3H*,Qk@q/>h?;$Idr=9Y$(%3\iPKm#@tXA0>^"s@$g/tCc$A@?_Kd%P*D*O+Ta_Mb4U&B(4U<fCPER(P8_.[q7H8fl;WL.lI6?9^s)rug'jS33Kpr9)<H-Wg(TtBZW<17$SR@p]f=A-MKc:7T<H-WgZh;24$LVWWflCM""dX!dj2.\Z>hF/H1>#QWAXguLYc35t2P"hr;[&M)3oe)S$LVWW$T8N3\rMJ=B3a(g_.B*B\Dc;A$7q`=W:$>g=%P@DL2?RHL/7X%W]/?8*5\/D=2BT:H`e<d=2BT:HZ$Q!Y6#+)p=M2umlIqWGJ]&['jR]HkJi(!'jOf.":OlPYYaeA$h^ZDRsN+,K6e87W-;LPVHsEBlCDmf?3M/1ST(9/"ddcoA&CRFle&)kSi_2dY2M^\4h'4I=+Q'OHYa_$f*+Ona"+?c2"c0-%Lp_-X2'H\AN4kBa6j'$._)HS)33ODE7ql2/BljWo0BtSfI#Gb47]NU$h'+\d&mGng)]V_XK/#2\mm:e]8gaV*Fdu4"Vo>MW*u?("ZB=I_iSN5D9>jtU"k[o#KBbOfsjCa'CIn=fPIPs;^F9Z._$%-`uXqU6%s5=l:ACr2;,U,=0e94m7q/rhn>c9I&l2b9"3uLJSu9.>j5"nlrsW/^)^^QE7_Wp\32b]N2tmR\.^KZX5L:(HYaNY=+MsSP\;/mn1\Y&]'J9dh&bqO[B%)0]+Za.X5Mu8GJ]&X'jQ!-_M*4L>ScdQ.[kY7Z0bG5_M*7M>aT`PAb@OW:iDC8\2WJ`p)$k;Y(M'gaY\/>mR:Qo=2X-8h(*\gZ)[o3HnXE)q.d,bh[((h<H',=$[;)dR>/oUSZS7?X5TZ@]jUfPHo5$?i14l@]a?CI45mJl2->%j%*S(hE;>rH2AM=W#0cY/e,f-jE,.;uZ+Z4MVef]D(\YOmlb.^(>dj*[HeMQ<p-LolA=S;skK1?:du`e[Cq=t5Y6f4ib>/=IY_-Qj'Nk.8a,^)-N,<n-Yp2E7@st*/QDmV<U$6QfbB=jI=gR-L'logP+ie/qhh-d(So+Vj\;k^bcqMA<(33[Cnoa2N>6enJa23cK/BkVa4g.I*eE03A*mJe9P2.Dk$0l!nK"L(lHmD*u0A*3:]<A]IO0O`[fP6BT/mY`C,7Ys#K:A$ME#C&q_1e(b$\jiZ@$]5cJ")Z:=BMQceq'+;\a>Psb_;;r=Br.+Ycs;CoO]"%$@@TVV?Amd-cf/NJipfP!\\*#$??h]OJ=r%6Lsim_cHWPh7Y/ck'W`Sk'Y%bS1D*oACbhf@*B?j*qK[R@kJfjRp7\*@?ctC00+pcP,"Bt1"tb_Naf``.*n5bDk8V`=e;gN.*pL3oUIQpM31qsne<WC\_%9e0'bigb:6#mX:%TPlU$iZ\e*tV*(?D6U0Q9'kZQJjY+VkDpD1n$7o<;Ib%2<OXfQOWAX0#=WuOQ2jXA8$7T!2HM6b9$PZ<a<XCAQ%<K<fTEg4`s,bKO2ZO?[,Af"G$Rl@rmD>)Y-kC.\ro#I(m044_Xo"OuYq)!=`%:c06_/Alf[$El%8*dL>gXf5f=kS_,5m[*'j*cc\I6oH4qX/a?%/QZHD6tOp,!$>Dj6q!FDng>GI]u%YM_gB2Ri\ZZ>_K[MqO"4-k9:o%1OD6lo;4qfdFdgAAJ'q<&O$=:qWf24WG+*9%\u7S@jb0qeG[ufpfM3BBPDBgK[8hRnaqb/Zj:SUFl-PLU,X5Xm6KN<.3!bb4UuK6c"2`M3t=;i6ehR_.`/G*-,e.pe2)Q_Pof):Xj]SSNPE3!a.$+\o=1kG*io&Ze8T,U5HF$_%*?Bap%:T,ZjIeoAJL&&&\jAe?;;b6RZ,LEi+XsTo?2p\?r+N(4S&:aV6;Ntdi,M>"^J(lNnZa$iJp(Rq!3_,GfqSjH1\-c7lR&fohYN9G'Z96BF>kF5+KYt<mf3f?U^ekf[kVUHZ@PC45S_IjqJmZ:*aFMUFU7FOgLT_1-\i[CrQ_KI/j4dDX[Q0d]qZt~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<c1964b437d0b960cc3052101907a99ac><c1964b437d0b960cc3052101907a99ac>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3970
+%%EOF

--- a/paint_by_numbers/oak_log.pdf
+++ b/paint_by_numbers/oak_log.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3232
+>>
+stream
+Gat>[5E?f)&]We"T4.dJZ@_fBTBVbP-JFb!)@#PdPS#Z>_7"#BM8-c?:Kqc1&6":3#lt*IOFC84h>82&\(nWtnkX`5pQ*'?bIa,&&)ZOrQf[>,-+DBiQhS[q?f&GE]I]mB5$j7kfZ3S>O_[U&3KI`9[Zo*e/hasjhu*/bIm/<f5(E@tkN.I05Kg7f/q<cfn)aLt5Q-%Vq:G3.mA#iQjaV4"f?W:Ro&_sMnb?'rlHdfKH-*Up;V#^<f.A#>+%n&^msEpY(VbE(rc&gUCoPu;0=uTd\SpkXW'#HFkuRV+cFm04G,.!^Ep]0.\*(-cm@_&fReh$4CU[W^7n[DD<;*Dmp>2Q%PdNa$0/ME.8$]S7LYX/0\FrO;j[f*NT%@klG.3XW;5rkXj@JRrMYc'Z]3Jj6QcdI-XSZ&824T$YFf0+EPp;E-Mn6<tWFflQ<DK?TF,RJ2>=n!\W7t/17.T'LgJId5H9\C`:ut7AURol<e`03.F`%_1,d$7n1#-eECT5g#BQ>;+8r:Q)[AJ@XWS>e\8<1?:\"RY%OdAb-QJ,KU\..2X*2U+d2<B")L>ICAe.1/%5VLSdH7rQZ?Dadq?Fp*$?7)`F?F&<K]gN\/#3uH+9NUJlF<,[qmZZL8]:bM4._X5UQ!U0mH@tl?]hDJk%CQXjRBFsWNN;\,?)@;DFm*DJ:O7Z60^'ggTJosTk[h=tDq'3`b@Hmpi:7f"I8+RF)p-I]`RgVIH&4*5*O<q@QcK6b+hQRB92slQ>;^TeZc9/[>#Ud/6="fCL+\TgFGHl//l@>5rb=aeI+HA]<ss#).`<@-`;u=H!aL4WGY;T+XZnDI-*k[q>;^9\X/<#2"2gGG!a@miee1tblRN'Pl^mfkWt_tDb;/@.pBPkD96=V0f_)Hp]"iLUk'Ls%/@6G(*k1`Hj45=(]Ht/YG3ftL>b\:W#3/$T+q&CCon(upY*&%r$Zh.Ubk9"6FGVWs%E=+56l5.b%lRpakUO4D,r9c.Zf\F*#(r9+!aab>a@g%eYC@LMhRo\TO%dr*C6H.$OC"XhHH32_"9[$T]joZfQcOd81$d4Kh_f`YEK+;!$[TjrpNp2?X7QVVJmKW/H@tmBhYF>%4*LKa]gNY.qVrL-6l5LllSX!F0'Ec,"hd<*l1N(SHKVV(YA]'@96<J'D].abZCj-!8*SjTP$4%S-:@75VHpnH7.`6?coZFB4hXN*oT%aJ9.uJ4^&GO7Qfo@$rd$j`dfmGa)F,t)<I09T.(r:ioEO>*]gUK9*P;(<10MscAfZ2c0'MtH"6a=-T\!O(k[h=tYC@KV09J,<rGb+VdfmGaHBhe`$[Mot5]8m9hCJ8VL2B09>*Rb`f7@8&X7T`0*kasCl+M0ZHAS`O)iSS)c?DSCV<cN%FHt_@fSj.2qkQ0nJmKY%oLA-M^%5OV)lskJ&m;%i(t[st\k6lt0'FUm8oHO>kU!f9H@r<H4.c\i_.2-]-+Z]eY[5[LA<l#-1=4eLZlYca7DlRU-[:.Vd7\RIn(@<s-+]anm'_7eM(Il`a#/2+]128Ap#m^5TJr5SoFbH+f=qba09HFO_&>T-I+RTTf)U,R/EdPKTU4ko?@NDR0@9s:rim?S6s&XGf3n6rB8p5I>bdYLJmNr?TU3`OhLIB.>?[3I9N/-.fP3tg#(ou60NlIYA=[@ZR4R8:ZAuOb(%)R^m]\dF20Rg+R^tm&lM=YV94SdnU$A%=<+53VouN]M)S,8G+>-NF\F'h8>TsPph&Vll6l+YUdt1dJX5(;(R^Vffe(,PjYU-Tjet6!F-*"3#2\FQB3UO4NY@uSZ.M%F0p([Y5QKZ3>TF5Rm0!HA.c4^US(>=dOO5'K5EU0gE]Ht/Y2Wt3IU9!44=\i9H$ZUf=610-PaS!/!QcR$KIgq,bd07*kf2J%"6='UW@I+V4A_/$Ugmuc[]DecI]L3S*Nnnk309Lt$!G+lAgX!6E)tf)CG3ndmX1(<r;gOk7dMm=o?Dadq7boH*9NLDkAEuCl6l5J"j+:U7X7T`0c?$TkpIT9[Y0tL(Q/50Ch:##=6#SH\d`Z0dhI*sgQg$!5dC;e%doC]I?&)a`qkQ/q:k2jr$[RF_J6o+RoEMcul"..mDaY*!IJ+P(]:<3q[m.!I]^o:A4(b$2(l0`u%Am-LkGr!7XEs5.B2)Z]=AsE-$ZsFjL[KOjbmfD]\arg_4(^WrVm@`<R([tm"&T63rXK@lq(0/fZLE$$$Z>pn)Ro<@e^iWZBffTXD#G@k[e!X(lSAWYkGt76:^5G7e;Udjp0,dcZWjc%kQ9MDlX<G.U$^KTZmE$9f$>8Do3Ls2loI@#A%DYam!@S&>no:8(ZH'1O?7VKEp(&HY((e,/s-=KrcS`VU'l,B>A!.5?*NXuf@VC\lE3@S\N?E@G_7X,-+]2i5;pSUA3k-!%d;Gk0_FL+n0tj8E<(<A0'F=fh@g;c(\EaDqr`-j/ElcI21"Gt7do"&kU!g52jbER&m_=maF[_B$[VbM1OA5r7^'R5cq@n8n!Ne3-+]c$?a%jMF@!+F?DEkN._Yhk7dk`UkRG+rQfs%XTW@\t=jS*aVY"?B"MOKp@TrOc-CCmW4(]LXRB47eB(+PeWp6b%"0bF/_61NTW68^Oh&rc^1>+%d_%+t"VQ/d==m("@6l+k[4&BpbWf$-"/qD,U(#32!op3_"\&#FTA$SmJr@6;@WmK>3?GMlK.^o=keQSiMecpAM>!4m#=uj-9h8Att@(NRcm!@:s?!oa;*GpWa[.W$Ygs1,'>CToLQKZ1iJ%Z%=d8b.<2*bCj$ZUeVJDBt'OmB1Ojq:gal]5iF&m_.LN!jcb0%:?A@$g(,]D`_mh>+._leaIMQfnKWIgqL+a?n`<48tZ2h/DcWRpY(C=!$mUn+[9[l^hi?^V'^9rPq\U5QC?8gFlbimjaj]f$:ZS8M8EDnrcVj],^";T.]]<7hVejHph($[_mP;?e2i-TC3aNs3irslrka!.jt?OhF-Spo"2SPhpq67O&XD7Q$\fhQ)if/a.'Q[9Wp5dq8-Iq'(`/9-sK>iYN7N,OVujpl^u=2L92Q2lq;)qAs$)l57SjpFbmUL.;'O_X+mSMo5BPJ6W=r_b^46hZA:%9*jU=Z0WU^85/&ucq.:dLb4k2)3Xn+3,hmd^^R7b=&".Y;(oO=Em-Sd4k:6(2Rd56HeJ(!(b7pF>Z$kND/+5(q,--f\<,2:[7j6>DL=j4"OKY)S#BH6,5>L:lO*2"3/8tLuXN%D+~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<3aee5448a863922bb6d6acb676937a61><3aee5448a863922bb6d6acb676937a61>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4235
+%%EOF

--- a/paint_by_numbers/oak_planks.pdf
+++ b/paint_by_numbers/oak_planks.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3251
+>>
+stream
+Gat>[9lKC<&V]3Br=oI@8\F8k^WF+2[B46b,Y5;b:2gmdZ)r_daPTcd@\"\P<hYRj^qLBHGA=^YNs=*Iij+TZj4cf5s(,?I4>),2LeCFbj1gp_6<PAE>J>O`o_.sbV"4BT["V5h*fi^J>=c;C9AaK?HeXn-?^BULjltskQf[>nq]D/S55dJ?r-A,(dne0EIXZV=l+_^M*riQ/Ie=TdFnspmoe#k25CY`6fNoY:&++VGQgknEUpS^LY;L-qD+dKpocCaEiRd8S+.'N9%6<%Mo^R<<X6"3$G^A`(c/U8?]i!UkKf,`LmA=[.`DCp7W,>s0g\0XP]9SImU9]+U\[?V*k"@V7/aR249K.q_=\J1#2iUO:>GeuA96scc[p)d%>GdEJ)I&C!c->qpp+\4c*BUS#Rb[>f6[QF3k.>nTaiM&k+f@3Y8?G3"4&XL5]lA*b@G_`@)Y2OC\2O(<jAnW`4*;J4fTNs[pGCrJ$b8*3*QFD0(;4O@0rug&VkK%i)5apAU#[3i\l,H"N%N^lF\bB(/Wba(/6XHKqTW_&=)ruN[cJ(DhACRn*^eW#H8tOP?(om9$GB,7ke2)e/\OhYk]O2(Qfs%X9=N^*bB/Hp9=Nd,bB+8@]k%b$RB4d$S-I>5F@!+Z'mc:Ld-G7s?D]7F3m.nWRBFp&FbO/!HdM(0"6_&:T\&K:]hDMkFY4#pQcTTJ:0-UrCFFV$8;>tZI#[Yk1<<+!+n$jq_+S;>YFQDPM(7:<X30jX<nT?s<n/M%:tM9SkRq#af,b^i&lk<Gb#X/Mq5f`pAg&d(Kt):@i"B1CCM2TXObL:,N[_G*<k(#fWpP16[5AJs@S:6_Xdp2BM(5Si<NT?5\VIoN9Mo$J=H'oMF^ZlLKsg)]1U&1:^t.b-[R:nbg<6/Ec?GOXV[IF"0"eTY6,=kY!q&)'%<74U`-&X6GJ:-=g<0J;M(HknZ9Xc?!aU-j<*c4+Fe*fo0$tDWm;^\4q5h0nF9+&B"haOa5[GWBH0oU:hH3.(>GUIW3K1M[H\6n5K&1Q-)tXbKd!P33H[:N"kdAH2HKVn4YL<Zg6l5JV?-l5dKjH,7HAO3:[<G@0SaS&Ap:R&baF[_G$[RX^k]OJ0Qfs$-q]]'eM6>3Pc<;lHkHddadfmEQ(\HFZ%.k08d-D5lo[Z0Z;T=F4d(?HSO7*2-*<rAKHI#mW('E"h]h\<pQcXhcHPo(%d8bM=h0MjMdfmG1]L":#'mcEjKjH)6HI(Df:G:*qHL6!3?7$&+mF;BR9Gd=^?(mVLJmS>K!52'-kd@aiQcLYi:06Xj\tI[>*qV3jd-D5LHJ9KebLATlC>[%98EK8>,j6Pc6EeuE]gPrc]l`^mXN"e)hFlG0^IrZ7Y;<?096>koY7#Z5mQn%C"hd<)ke2'iHKVo5f@`(/94W`_0+3)_Y0cKW5qgV#HC\nOHAV&UYEMt4kHgi5YsIV#\jEUP'mb_<d-FO5H:ne7eu3dLe2eZ/'s*lD)5*>[JmP>_HAO9<4a6A`oeK[sCM/phq6&.mmMbhGR4d]GjorFd=6R&9:$Et0T\&F[hYF>&CNi&tOTiEn(A&5Fcti*=dS"[JYL<Zg6s&T[ZV'\6<p@"F$Dj*QJmN(rTpNiP?AC;_Rn=MNVQ"bre==B+K?gT*-4>)p=lW71P6JUB<no"$E7\=sATp>=m%1N6$XP"bFmUa,-*i-*\[#s&;2)Q((?EbRQ!?*QEJZ0`[As:oa9#U.$ZCkQ]X>*(QH0EBAlZ70YH#$S(>'7&?u')ZYa26)g/HOJQ+P&_F/%O=:uaShMKO-F-+^>SgbjOlK'<>@B3ruOa?j)mX5)!EQ!:-oDi$*ZFh.R>kR+inY,Sp!(?1pt`fJZ+Y**RE@4m[r\P<q(&m_/G0<_BKFJ5in0A%S^_QH&)\iZNaGO9Ab?D7gPSZ^%,A0LD%CV6(:oKB:`;X\9I>9=Ye^4#0qd*$NbhFlJqYo;(+H8"+OHb2sPk]O2(Qfs%X9@rsD)UfFI]ro`*F:W]2XO,.$KjLr5oFbHVlYN';b@H<50.ZZM?(om9$GB,7kk2MR0@N)JF`n5d&m<TIFbO/!/+bmb#e`o4k]OmFHB167D]?;)>P2n$&m<$9A-).H(@Id#pG[8P.bHmcNVDqfB2r4b$[(X=5hB<E7<^pGk1UcOk0@$oY*0%"dodF;c9g=^._rGn<l(?Q_HZmWW42A$E9g1*DWe@#X^+qDVlP]W]jZfcHkt9o=g<.a$>LTo5cm`)=?FN/o7$H2d:t8\"h*TsnI>c#$Z45Gq\or;(>RWeT\Rh:eQ\pZDi$*^[?j1q-+Y;'PD-M7(?F2I6-5\dWk%io_H\8mFIau0-+Zq)ksA[M$[1q!<Ha5%\8./+m`oG[?Mfs9]L3S,3qJ6A6l,DU7"S`J%u/rN%t)gmB,lG.U'l:<0'FUmT_I5!kU!O-f?PkZo3J3egpM#R&7*ZKF?qS-'mf7Q;gO9Ok]OlK^%5O+fC"5s+q&_ae"H=G?-qnZ5qgUh^%Sl`]gPrc[Du9nkHdda4g*4+F@!+Z'mb]fk]J9eHEkZs]m4P62"rpUR&nAUc5Nm3RB43iA.NmPWjliJ!SA^(@/$0KI\Ohm79sP06'o\7kh7NpF.'%qHd3Puf-R^Ff3VVmQ`5kP:0#)@Z3%2B@ITT)MRW;>TuLURDXAq',-'#@aU5IM<j6_PLUBfUXEBa.[Bai^[:ACN[GUu#0ru\4YkHj05*LQ^!aDQQg(IP%CG1<\45X%USM%Q$]("9W"pL@W$Fo880uPBD&D-/uh"e+9CNj2>ObL@>l70A5([0SN6.I9m:tM*Olk3T4f,e#LS^4=J:)EC4?,5cJ7:%/GH*-G"pCI4^D]eg;Y5$`^r=tfC%lpK\GG'BYr58-L^Rd[i[WV2X_W,Zt[I$VcgR@lDN+\8ffp?&q\B)F&@7X\D<sItph=M6<BmogBpuLB'5FlF+CHX!_7rJ7Fp^j.FbO<.RB^<QM\3Y%+]oF8ig:&hlGl-fTLbt^VgLjuEBSc1h6L6^<L.Gg15<Wfnp&'e%o]*dB=HKYE+h!QSg:n)ZlP<r7e&R3arV1O*o+60UnTER#C$1gQ@iMj5C^jrl_K`SPhZ&#[Nq(q7=?4)uIqUpl?Gb@]j5ZKG'RT/B`63Ug):IiELuYK.YnV!/`s$hGNt4s9rO>Nu?`//$9)7U37G.nJ)`An9pPl_$aG6Y.L0UTh@uC9QGjbMc`Tq[:H==bD94Jjghcq<!me*h*l,P0^]Ep9hBYCS5ldHQkVuHib-d2k~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<82f0abc7e9e59802ec9aaeb6ada4c490><82f0abc7e9e59802ec9aaeb6ada4c490>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4254
+%%EOF

--- a/paint_by_numbers/stone.pdf
+++ b/paint_by_numbers/stone.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3032
+>>
+stream
+Gat>[9lK+D&V]3Br!EMY,[T9qIdh-="(\]W2R-<9%;a!Q&1`8C+FcVbA_&;Ncuj<RTE.\$4Kh@Gp7ldiVt2b>>CQV8O2"H=VjHYoTC\;jo^^<W\(%:An#*q5I!G[;R7_gR^$KJ-YNI^(gQC'4fr&[o;EiZAHMM^[j57TKqt4fPqsrc#dm(SEdQdakrUA_E]Y4;YHMQ1bo%g('QK`l@k4d$Us8(]E@"3R!*^%3`gQ_;u8su#[S!ULKFe;8tlaGp"5Pa\hqVa>1=]2@pT!nWnjE52*,N[,CmbQTHRU]QuDVNX19;10!Ve'YUeD98omRO&.]qr"K.=9QDf6(ZX19]pj7om3t+-O1bmG9GhDL%`eCR)L0ODJJlmbN3X/gZdr8uG&@LSPtQc#,*RI9nAWO3"scKs'CedTSToCoI;ooPA%/ehX.lV(L2G6s;U:Ha_b:Xeau*db.Io&]sXUd;dbaXm7.$%CI:@D6NSJW;E0$>I?Wd6djQ0N`sUdc)"$F6gI7<RmPGU<bpFO=ZRL*59tS^)XT.m&l5gI[+(,AYUo!DpR4/7X$Z9$jOEn;O!e5.=6UX:XD@GX?)./FX\\1]Z:6Jb(\A&?cqD@^]h6o?Ab-hR9)#-JAW:"BC\4p8d49<)0BjCg9%N3;=ef'_)SN4foI=.ApXX3-kuG;B]d*u3Ke2F6G7)]tFH'V4?DCTD)SM(Ld(@T&D>fDmkZtg(3E(3W/EFKTCB1Q""h^1<Hg\%5KtCdDfcAC"]AX6)>p0Suj"/OlZA*7%Kt0Mbk/OG*\`6g?2k1ZC$<;m$<roIc"h8Ofh?mD1)r>Y,>9Re;L/liK]^"4j=^WajJSgo7CP=7>ND0P`F\CJo</K>;p1;a+=t=]'/a3=@TaP\?h<.Qf-s:4&B:[fIY&bPc_7^Spn<V9+E.tHG9?)[q65JRD0$#(%3k=c!@'5TF\KhQ)KeC`3fAPp$?)UE-?ruP1]5cEX*RD=/f5C4/=6K]ldPZ<(/EDes:2aH:c?kl@/N*43[V&mm.s+)G[2[LDF?qSE)SJHQoYtZcHH3Wm0Bn'pTaQ0<(\A&?UGq&4djnrp0,YSuNd%&NG[A`IA3oZA)pp0X5qhJS?D.aQ8Jh"+?)'@(3kaQVV`-dYS6hlsHK2=4oEnaJ9?8i6Q_UA-qAiM.GFm:7Ih/bR]h0+5?G"%sC.]<7P'KiLPq;-YZ_1C`3k_>)oI=.n9=dTrdPZ>Bf'$,>TU0b[?D6]W`a,?@ab&Ab2L)5fl%36i20tN?ke2.lkB<,nd2S,SHA/HL)ikAQPqM8Ho:GS(=jTei"24#_[^A_/1b@D<:Q+f1`DEI6kSh.DDXaT+ko.7:C\.s:U\C&`So>7PTU0deYL#.Q=Vp];h32/c2E8B:f'$]*K&6#MkTsN].qFWGZ3I4.kSh.9$[RN0dEB+o=6Q7JP5C]s4.ZVhX:'?.Y0kG(7^%n2H5S`9[r#j9=6YTsAa/+1!>_G3k^m-h"hd5=oNo/U?Wg=5TJt.W^#NCr2dV-c.s+'1R2>K&?)*aF$[RLXkTsN]45P++YMJ,6YE/q$,R\pP0'J;Hi:I@^cqCsC=6LR9ERs@pcT8c0HC\B9$[PCrkS:Cr2pOItV5=0!>.UG:W?j\E,a\$N=i_Op!O%Rg]Q)NX'rl6I;N78a(sb7TiNTJfOG1:9Zp7^6)S0o'jpG+U)t*dfNb=p<0FMlS.`@=I!*@5Cgi0[hXcS7GE>I=:=lVEA]!gX!f/CnU>9OAjj/cB6<+50j)SE/[bW0OJ867W!H1#m6R9n:6FC?cc!aD?+Cp2Y[>9OAkj)LXEnZHq+]'rba_HYFl\3ef_NOS65$<`0X\fc40lf?&kQn)]UDS07F=6K]kdY58!([@/@J6ejam)E1PG<G3ZOtPZ-\q$,h9jStNGmS%ODqg:/08jp@6ef)!VlSRYs'[j4Q*/M]lNZu2?)./FIK!:pPcW8*`Wa%B(\El16*J]oH<Jk`<OsQkjD4h09%N3;?)(KbJmP_eUK>PU^#Wu0]h6o?A`F]B9%W9<o,>;7pS=-d6*H@R]jqSF=6UX:XF&BrA;snb%d6(QMS*^hH?l>'1^I7"9<s(l4:?@)f%_:LK&*s%ljdZ6?'9oQj&r%%bm#i"$!B'N<+53>($(MuJDB+bM]6:PmW]K)Ot+6fcb`nLKt$)FE(dLpG!'Qo`ohng4'ZoE8J]s=B45Yi"'@Wk"h!m):9@6m=PLlflgaW/3EReRJaKia]Sr_0Te5Mt[R(bb``_JJ]^+FolZI-"0#5/D,B/@>M+bjB\3^tlP4aF^nZJ?#G@@Y9"hO4B**o6GF\*D7$=0l_m04Af.:%!RcFUXJ=beq"C(@GoKtLr&P?5hW?:#.c[='Iqk+gs8$@<dfl%36i"hd5=oNo/G"'m&XHEZ"XhXRbt9=gctk^qZ9%8O+R20qh0oEnaJ9@a)ha1G)bg]bAX(A*b@kS:\%2dW]:.s+'1l%368C\5V^E-fR2:+tj`?D.aQ8_</@ZCmO\B(TQW!kn8/]4pmD"sn'U?F.IX?6sCVP3hG9;Di[Y*IqE=$[,+me5`fO0$,$C9(kZ><6\[EC?C\\OXjs.DO`S(Q)][6WWoVh2/l.<]N)9"/]h0jae%9oX2,GX65A4;XC8/?%9nuYX];B5D-V3umDpa+p*2NB)nghhl,$WP"h$`6fTNCO.qG>jS98_i]?W"m_HW]ADb1c'$=*c.RLQFK<O*1&F@#>>f?'$(!-<iFbe7V@bJoc!cm;tr.s.I;=Td:k]#JWXFa(m4mV[D134qQon</&k?6K]%U[4o9hsWM=^Y`tEa$4pc?eAVm<(m&c$FK8/IsuhCl1O)gXXEQdS<e<Sp,7?tn[G-/o$;[J;RcXjcMG9Ar^m-p5(.XhF)_.Hf@g#'qaCCIli46'h,"#0rF,a(\6XjTHe@M1SpgS-I>H=$ZM4+3r2(X[dSeq:\IDF4&DQBgm5Do2Nk%hjIs`?4/pkaOs4]IA;7H/#MdM7<O!36;FrTGGrAoB*nU<IoDi8LEs(2.'LSGh@p%=pF):k]fpW)YV`Ur-hWjR';~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<4a79689fde0b53f2e5af4136e6aa49d1><4a79689fde0b53f2e5af4136e6aa49d1>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4035
+%%EOF

--- a/paint_by_numbers/tnt_side.pdf
+++ b/paint_by_numbers/tnt_side.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3434
+>>
+stream
+Gat>[6'!"p&Vf8VIRO@L,X*nVZ:Qrsds@iqS/d\TjX)r+)aUQX0DYLE),5P0Z^<67[h`?X$i(f\Oo7s`1%)]Unge)IrUXsNo(96cq+G%7=^M*@j=P5lb>6=EQOh]OQ_eMbYEqE>p@Wf+j>Kr_F^N/F;P&:h0>B)gr9Mu7^4';#IJrunje#n0Ps9b'?N0ZhVrd#)bKCE_6>F^D5-3AUhuE9+pA4[JAL)JHQ#B=@4dE=]AZRKNV=.&+WK30srSdM&jWA[S.P93)nhT8Fah;QC"m*X;9=N(<1.S7RgRcu$9%`Mk[B]*uGH@e4F1^n,qsM1pdL)812:^R\ICA!DbM(Dr1Gdi2>I&-h6t7W62KA,LlH5EOZHf]/8h,1aN^Jp\WH4,t>K2u+XI%)PNi]"@E4g7f?3bTkWbdN&[qH2XXJofH$<;7[/$jr_Xe[rbFW.:H87)1L``md_]hdoM<8!G>f,9RWmX(s<kN3mkZLuS!/a'L,8tC]2G!o"1D:iSt@pQ(_YfW3t\V2qXXXE\$ajAHo98fYTHM_#IhI^Eam5(YWQ[(]d9^--"8oN3ZHC:qaHe5A1l"..mmp1*`9J=cs]tkON0@NpIUTW%gFDpdUdfmEY<p>U`X7R$1cl7p0l"..mDj47JRBFsWN#2+A?)9Is0BcuY2gU*2J6jE-HD@XkbB0$+@(])bP>up]ko.6`:"taCajAe]f:53RM(I`\Z[eC`!o?;qEL3W@h*]_&pO(QEF_>+I&m;1!B7V[t<HR'=R^kg$k5(hV\`^:gXuc`A92m(;?Nmr-(>ud!2/e=&]QH_[g_*cOet%A+HbO7KqH73!A:^jE>$+Es@BDUoUUH1>AucWR>F/dJ)-T[T@;X?p[R:qa*kRH@6l+JtZQ?U=]>gs;#4n/E_V:^kE/C`LlVH-N-*e(@(b`rnh_fHQ0u.$<$ZgqOcm?7gf,q2q96?l15@.idkUO4D(sLh-=`ZOc!a_T/Gl@/!?6Tc&rTP66\YYhj9[R'ZP')bG?D7gRK.c@6\tJfMFm(-WT_FiHkWRf\HMoQ8]gN\/#$oSKFHp0^\je?8"hh`s61=WPdHchooFb<R)e;5fd075_G`?%($[VdA)SJO?l1N))oUaAI]g3J,&m`lMNu.F$=jZJ1(\G.=d^I8Oaj@Z&Bup1e[G)bObB-&=Z.gALbB-&=Yra#Tb@EoBT*;nrfBDnJ!.(%ckRG*q0@NpIK/"df9G[7)?)<nO)SLT$l"./nf:O\ZA\+NnkUO8>(\@oA:jSP4dd(O309J,<K<EYGF?sil^!Y#66#T"6kj:0c?E$^W['@fZ-sK4qd8bM]]#15.kUO8ih>K(A6rrO]Z:=<Y0'L"7:5</MX7QVV20t,INS\=WTU3_L]m&<#d!NJ7H@mj6-*g-]Y\Q]]d8bLF>r-e`Y0n8*S'alNDtF6:U\B-OoEO>5HASfQ)k7,Z94X=ELe,n)NO8,EqF!\dncBW3*Y8X(M=/sU1gJ%Im,lj'QO(LcA%4b3QcR&#@s0p,T'r,]rc67iU'l=#0'jmqC@<nCfh5jaDpX3OkIY?056fb5A7;[V>dKd\_VS\2Ya=Rj?N2K5H\noZl]8mK4eFTYrT0K]6l5P$?+$$?_VW(!fNYd0GLP&3)Hn`W_I.K;94W%oHcULtD]l?9pQ0NHgd"itm\/q%nt+/G]C'-&>p9Z!r@H;AZAPeL".2_\@BR@IOF'0,jLVCG\3q(kqGi&=A-&i[/XX"8(>emjE(a`,gI$*Eg7GL:[dIT6>9^\]WQfg?%c6"!!F$`UCjfo'm@)M&L&+J1bH"k_lO:$E]"n$lomXhEFJ8*,leLV8=`A`3HFLHJ]B661>Q^>V!aL5f-8*\GEK=7`>TsPrK/(0so3F0(mfHc=$Zu?r@-SA1W#I9(lk3U.)g($kd8bDh0c7RdZNdU_GYMM=Mq_Kd%$6gs6Jd5`V0<k7Xf\/k9LDNWr`Q[Xa@01N_]K&\]hDOX`Xmk>?RFQP3=dn'0RV?9l->gi<dNC%^I5Tm.OS\c33<*7iS*BeoGNE!?maZ@as3K3"D55l:4(1SR/k&k\?9%Nid2MCK:-Tp8M6qWG84O5]Zh]<7slYV0G>KR[5R&$!J[$3CoPp/_/Pe*DL!M<;2rm)+D/K:$QOn>&i8?M;sAXV-B-s=$P585>F.:sgtST"CB<Gd=hP'#Z=*HT<c<QXZJ/lBcWBcL32db3VmEl6%VB)KT?lg$Dj1F?kHhYPhe350pO$!0I\SIX4e9R:D_M:/HbQNS^/5X3T$Q](D_M8\pO$$1I%r764eKFDp]`N.E)0PTh]$.CmJ3j?p'*;Q[ca];f,H.@C3A'c[Bf/,cA,1YJ@.c]fEPVh96?lpZ2=<[]M'*r*jZoskI]lY56g_FkQ9P4$ZLs*MX+'i`$M]32]+3h4l8,<r@u)m+q&LF/C5]S:tHemWCq?LY!66&QftH]rYWl8o3$])kQ5(b$[M^@6=(iDHN!(H]fH[YhE1t6&jE.Cl%7cb$[RX^kWO)0HAO3:4_?j'cZb@TIgee"d073L(\A>GV:V?Bd7\"9D_PMEHbO:fqI9N=6l,D!=jTf`6*ELZUR11r?@TUW0@<dGr@o/&kHdWrciq*N(\IRa"hd;>o_R#?]biOkDk0$sIY&0Qb@FW0+KOue=bZU;II&Rb<HjL(LKu)3G5W:D>pcW;#$FB]akkD;-OY!`WgXlc<llYn+P36:MT\t!gn:\*10Fe4+"b-:ZKePV>1Ar+NE^l::lD8=gE<QL10MTI+0A_i<7P0%Z::ta*(-jpgq&N$:Ha696l4DY?!p<IJSib6D2BgN4_?ipcZb@QJ%=\nd=o%q(Z5p3"ZOLh>TsPqKCOQKo3ETm?SBVLZ7n5Y!aVN.FFu3q-+Zq)+0VqBFHp-]\`W>UXLT9l!ADh(]KoW\-*iWaS*nc"kPs]1o7,kZJ+WYGfN^qHV0r;2g/"oe]RKb0lc6K:#L=5^1QT80-'^)a?sD&?AbQ#lq_*0aYBpn]2u/?8^:2qt+Q(c!&%?0XbC=V=S'5&:,Y(W/Z9A7:IpE!Bq9rC9nafFG6G$K?8VjMEo)"lR*0BJ1ML9'gVe!MW&Z'=nO':re;.L9b:ZY7KFBh66rgfs00==e_6n@hnmu+,]:H>W?I>b&ap-4W\(K"`U:K_#bpmIW$qCW^107MT>/;oX7&%T"7[mT"(`(G<]Ib/baGEqm0hB'``X-gF[kMtT#oB!0jRJsg)'@X^CbpKXijnd<Z)-D[\rpodWqshF:'c?u,._;_@a3U)ZGH:L&D`Nr\]O0KDHS^(uVg@7ma6bl>f8j-A%c[*OHp3"N/!YKB"`d1H3<aFpb-bMYHb1Bg=bZ7`E>?*eU(3m_paIf*"tpc=Y/MY&L!9#QI_9;.[NEOi9Naf5b+Is[a&Rpef8\um2Jt.!\&i#>dRK\-m-i_l^<53c\32]o]j-kqT?>UppuTEn!N&:)Rf~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<1253d4767bda58ad84d2b4acc16faefa><1253d4767bda58ad84d2b4acc16faefa>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4437
+%%EOF

--- a/paint_by_numbers/torch.pdf
+++ b/paint_by_numbers/torch.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2155
+>>
+stream
+Gat=oc#+Li(e+1JMNZTp(.J3%A;B7TS$7HHZ&=3*KSYbriUs/kpNNZbB`!5rOK`;VX/`5Gl*3;`Dqt->?iKrmM_Xs=oAdq3+3aOVj-*4"r8,(Jhd*r;9M!@Y6aLWYh603@e8939RG+t>]l\>p@c%%RiU=f7oCV#%BCl"Ucf=W+k5<QWO.X0GkJ,7:LLgm`c+eJj1<QdbhlSDBb=#jUFe0u@IBas*CoY[eL!iX#[aaU.r8d1=q/&FX=CA=$K,/BH9hg8KA4$h61:Ue?k[&mrA^a9$TK1ZOU1OKo9t$*k2/'2%`2_L@(n?Rl1Oi*7p)Z%0&50I.FNk$.ene#KZ[h,MFWkKX+N8#pF.*P/\QIZg6.XJY*FTY9X9qp;<M6CoS:msN<+K"%,-(b[=V[mVb#+:$6&M`N<+K"%+tH/,Wra#=($I-J_A1-qS5".]it\k?'XDaYA>S@OQ(sG+UQCb9OHlT&Q(jA*PE;')OHlT&Q(h2XN^?d,MQGSJa;V+]4\(L5*/1I6'j2tGA`Y=NjX=[$-tMEfA>L\bjWnBu-tMEfA>SLSQ(sG+UEV44"g\!p,I)/n,:c8-.n<$/8krML$<]@r=ZHgl3=8n<$<]@q=ZHgl3=8n<3b@D$AEBc2b$>T^Et:/Tf+kS@:m"b/Y-N'\Z78\5<Ip%/$<1P9THYmV790R@Z78\5<Ip%/*/1I$<+K"%X/lY0+D^5MQDf'ITKjYN7n$HN:0BRa=ZHgl3=8mq\p9YV`oXbB>[M@!]B-TL(\>XbT%\#*erLcjArL0IIb_.H(E(RMRi-/Z)/p9-:ip<b;.RI>aadTO$rXL9(!Ue("c<^J.N)''B#%8S^enXX;.Mr=_[LRoBt;SZfD%Z:qJg-PgMt\^#5$&M"rp&9*(:&GSJcA\)/rP1i"dMhOR.5Jcof-@TZDYYOoZkA"rp&9*(:&O70WlXbTI,%m)WXOI\?iAYd8r+YiRhGH<i<.NZnOb+p*YI#WR\I3%>MZ#8)OY[`4tc187#G!CnF;9$R]%M?l2!#WR\I#^R>=GN0A2r9%;WKaRJ4c3h#?[c7e[Q-B^sM@;J%$n+.mi$^A=W+<[qPRLIWf&`uYk+Y*e!sQ8J^e&(05U?L9.N'X2aag'T)5L;Mm'4:u@djie,(n^]r@e>&A]R,f8d5W%1>jQ9:nWu&!aRTY=GRC:Dc'J!8OPg8Bn1aj!D9'd8g47-_Z/606iBZ`eINI&dpG9)[!t1(nV[C\X=6@[iBAQ]4sR!$P_Agr'^r#GcsF^mGgB6CcVZEhP#Hdh_L7G2IZD9oJfa2A*-8B_f7"#%L2j-kgMpTiT3g1ZJ>4NCUI]p0ZN6(1!ffkVgd5No$W1HM;.RI>aafO1"-+Q-NZnRc+p3E<B&L:\-%pnX?"XB<EMH/bO2:SNH?\-F]sQGn8'q?-d/c[K#96/;*0h#DL=-+RbWAXodX_I*45_AF:nZ6f!gO60W-#i%UCL`d[^9+c)#AtqOhl3Cmggr,(PW82W)TETL#=@A<M36@!aR<Q8;IW6ne;gX'GYRd.\Pk(J>9&nUSr^<W.:Or'o['SY4gIR%DH9+RDF&OJ,H3Ur6f0^*(:)P70aNt*H2]5E)\mV)nWb:h-]$U5)M=G$Tg\3e]&/lT1H_Hr:KdVa5bq![_MGmH#ILle`AuLqtb#nSniLkQ,ZmAN%MO7a]RBt&*k1ma#@ke1Nm3.@N<:9S+k7ls42RA3^#=/rMa0uS;XGcQ$)(?Y$h/GR;SKRjCE[u@5i299\`BE'/*8pX)`W[39FhdGN#ue@pRuhZCNs]-9duH]pdS\D=Y2VN-ND/`D)gAHEtf7k;h!PkNTAPRgLI[*4iDS%rcoT51Yh!G5S4;@)mJlaC>t`<)7eOjYi*f<$'d87o85HD8Yof?Z#g;X2+Gt<`-jdb!W>:m/GR*96%m\;f6IMib"f!F`egI2neTDlM:^sbO:hA<of^uD@uF0cSE$Mb:qL#k7Xp.jH`fi"50iONE,&0Ed5'!7?B*'$66,:c`=W<OBYa?%qN;05$!d]'uOo(j2udQp7REF2a2-?S0sK#mGgXs`Y0fHelLCHK=J1Fp^j!GfIpaY)fZSC0.6A+,IqA'o14&J=Dirb5.pL]]4LbBg9MZ/glTQHf:DBlqFkd0`]TI@17$\Tf^PO2p+BqErW=p8pKm~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<bf43fe9367e48783680da08fa4264f8a><bf43fe9367e48783680da08fa4264f8a>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+3158
+%%EOF

--- a/paint_by_numbers/water_bucket.pdf
+++ b/paint_by_numbers/water_bucket.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260320123130+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260320123130+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3035
+>>
+stream
+Gat=p9lD#l&VfcN'a+5ops>H.R/YH,Zp\8k92*-ODh>jI87ESB#Pn8"=`(k.1RRU5=t[UeW0bi]<d-^^iU!^Q<k?r<k>/iGbL=Z*[qE<T\%MWSZ,)+Tjeq4XbF@8\h;Z<NI@![2hm[f_?))DejsB-6fFlBuo)&!E^OQ1Ml^-_Va%sH%^OH*?^4*]lo'qdmYKPDp55j[;O2!;#s'B$Ghbduirr6TD_>`ubRsQ<(^V++9rT:gFf$^\1F^*;*RI"BhS22lGS*Ces?^IDZW2D[LMNVY[AkO:?U,a("3C2(j6]*Bp&p8:<fB=O.bo)k]U]E(O;[=n1Q=Q^cOp60?)K-q2mt3Em3(X4"ge<YqdK#oGnKCL3#hGHpGtA*ipEm#CU]Fn^7b0&*esO.UTgZ_/'h!>R$DR:>3_s4k$DP19B@00YNp^4oCKY,O-KON2Ej3g`2`k6]V-`q[LKL,L%@6k!VS-sO/rtsCl`&'\%3mLOQNg)5&mX+E=<9p@QWAdHSq^LAh"et+jNaNf>X=T%<tN&@Y$c3&\T'JMd>A5WG94`acD*M4P@XOu\9R%Dg^Bg5XM*>oQuY4<;(L5Udg-=+.'PBlK681X.'P7U4r$7X:uR$2lT7.hA#g*N=P,l)KamlXa?Y<1%/O)95_5cn8D0?Gp8ZtG?thVfZib&Cb]F]&@cgNgb^@:$(nXJOS!PO8*ee&Md8h6$2),p$L*7K$IC\PWI&+Qp7kN;7KI#_]+gp+P0p7+r,IQ=/UEg#0Q.08Qa%6UhSCDRX7nRf>Pu=4^.k.^,;SThD9+!;Y1uQ5D$80!@hdoe]$8.7958;XAEbqB`+\fJo$s/E_2$/c^K`d<;3pa?/8i/Ge6=Z5CV8f#aF9g5b@gXbDem_!:@rcJ;=Nc[EN@DBa=Ner0N@DB=YlPUY;dc<(5oZIO3O`b)j`WJX^d;Q02H5Yb\Brm$>\HgIKuWuVXVt,W=_%E(W#Ck0X2aul>W"Fi#W+FU%Vol2c@eIC1Y8!:ar6a<0/^2@-BWZ\)Ui)fYs&pA;fJeW#$f`HL's!Kgi0AM%@8s'@aha)1g"Fmj`WJXi)Yj1\Z@Lp()lMJ!?0F+Ts=Ts6":fc1tLPqd$TR2)XCn,0a5"#CqsVAbr*?V'*ng]MoDLU-)X69;.sbY^!bQ!12VmHbY__W$7ouZJ1Ve$ago]CPANmhEn?>l'O^XeTF]R_$LZ_[,:ksS^p;!M>^/rfKuXC&GYE["O,^C5R"EL&)fagk"ZJHJD<8DLH6Q:<b@[8/f@r<g<,c9O5pNDOVC$l9k0AP"68E>:P&k8f-qlOU?CG]bBX;PWB0fo\"VrG#Ys";m\Tg@ti^./_/jqVU6=^EUMemota;!9C:#;s5XkMJ`R2kSF?oHHo&.FgQ\1SZQn(W]b3\F?]6SUU5dtThD#;T5.+gVat1/i^+AqNiXRE<!>B)P<(17QDh17N%a13::Y"$"Ee6pVMBRm\o@k+11TG2P+Z'eX:#4dF-o<FpS09W#W%BYs`OV*bc@a(,N0S#fsK7&HVDA8S_;O3+r_@sosdVSGN./[f:H"W%qi\NPcu\<,?n$\p1@m'(q_X2<rMWj(ph<eF*U!e\a'",!`,,k!!k.g8ceC_FE<QsJrQAK@>De6n1l2Rn"KXrWA@_,Xqr\7[N"(D](Hgs_VlbShGM$]ca@nCX\U&=FMC75b.`A-sq_G2W'nV>rtp#B8"#$8>^C!^gQ,0[":ZiG(//\([oJb>i1RSNph/nZ^;*.YcMVEn4,"AY%)?=#p^LdFe9B=\B3iF`t]HrnagY6Y?XC7qW_mlg._m7qWb0?"]pY=_AX(lg._l7qW/_F>a3,c88eWfob%:R0Lkr)f7Ir9ESmt%Df,%%J[*4;(&"m"W'3=bVF8uf*Ub:+<Kb5rZ_K69p:[l1s(%^#Hs.(6OY<p3'8'-a&Y.,fUeSn=T6Lq#R`H1Yq2aQ'k3>)iMAnWHX7>+X-NrpBM"5<Pn)H<Q/l1@l+l[X8^<$R7eOViEpilojBs+1O_+\u*A^Eq@\tpk__>;fR!BC+R7CC8PN8QOB`G0J>b9,jA`R*d.m.i6k6a(SLo(@M7&/\GBa.\,7Y-8.7X]f%jP]<l"5$nk7_sdp7U4#(!JYG$i1=d"@-D3%0m'/jZZ#]8;115@c75?0P`7JkGUS=T&L_95KlZ<Q<mEO)/M`/h5$5(D2!$>s@g7c<\2]R2E7^+='O\@?bO&G#JV?N^othnnE4*afgp)Ze$]?"7SL5Fk^p(nY?s#etk%@I![T\s;FLP=+bbG`e4N_-#cR"JM2:'5aLp@j#dCU7X8VfYDj]S3EY9#Cm&l$T:LJ^1u)XMn##?2ad%@*Ph1r/[L/$O81;'3tKY+bD"M[!-%E=J5+=#@_`JBt\5'([NK8eC*P'h%LH.i9/J/DiV,bg)uNfm/fpG+,Kg4-*i_k>BI^4Gr*d7kl^H.#)-$`5\B=Z!$6eCt<=-DUs(IRroe6brSE[I=&.2H[Dq0g9t)OFb8H9POZqH3t;)9lfZkQs*T7LN:U!2rD_t]7*<>!kNf=D&$rQR6\>s643%01jn]-\qXjabm8E/'g=iJM<"U\gL%3UC\'&uEgFl9@-DYe-Gr]6hMK![`Ctum;7CXodS%LfsiM_QspIe`/7U)Eaja;J,_Je+0]=Q%?nEKqPO1#<i7?kGlg*/'gB[J%cj4BIGYaBfA$.8j6,l.;1Q#J%:]_ZOM"=h4_nGL07LB?]>Mk^?j7O:k3,_=43QK"SfYS;jB[_7P/>CPJ$?nj:^8"tu.^Sg:_d$.aA:2BAr'j-A]'p5L%+[1B(LFW!um(K(H%Y]3pTBUMp/&IHsCdleNFcEks4m^&u[cdDRg+$tlYd>M@>G?NBpM!&;WM6Od>=GD=[WgCf+''ZU1V*8<G^WbX8#iL<dT05DMYDD2ZrKNB!^4C]?_:A097)lnK.@R93^u^=2^Bm5?/@4>?eq2j\iq^f,A#@N3L$da1V*I)0G`JiqF,kI5-;pOA^iRtPd-.1Np,`UP[X=SSX1J#V?E?Ua-IkCk/Ag^.%bE"c&F>orWEScPXY~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000061 00000 n
+0000000102 00000 n
+0000000209 00000 n
+0000000321 00000 n
+0000000524 00000 n
+0000000592 00000 n
+0000000853 00000 n
+0000000912 00000 n
+trailer
+<<
+/ID
+[<f4f61575347897b700744c755c9519f3><f4f61575347897b700744c755c9519f3>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4038
+%%EOF


### PR DESCRIPTION
This change implements a new requirement to provide "Paint by Numbers" (Malen nach Zahlen) PDFs for all Minecraft textures in the repository.

Key changes:
- New script `generate_paint_by_numbers.py` which uses `reportlab` to create PDFs. Each PDF includes a title, a 16x16 grid where each cell contains a number corresponding to a color, and a legend mapping those numbers to their hex colors.
- All 19 textures have been processed, and the resulting PDFs are stored in the new `paint_by_numbers/` directory.
- The interactive overview (`index.html` and its generator `generate_index.py`) now includes a "Download Paint by Numbers PDF" link for each item.
- The `README.md` has been updated to include these PDF links in its texture table.

Fixes #23

---
*PR created automatically by Jules for task [13156636964906556246](https://jules.google.com/task/13156636964906556246) started by @chatelao*