### PR TITLE
Reorder texture tiles starting with TNT, Diamond Pickaxe, and Crafting Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ You can view an interactive preview of these textures on the [GitHub Pages site]
 | Texture Name | Preview | Color Map (JSON) | Paint by Numbers |
 |--------------|---------|------------------|-------------------|
 | TNT | ![TNT](svgs/tnt_side.svg) | [tnt_side.json](color_maps/tnt_side.json) | [tnt_side.pdf](paint_by_numbers/tnt_side.pdf) |
+| Diamond Pickaxe | ![Diamond Pickaxe](svgs/diamond_pickaxe.svg) | [diamond_pickaxe.json](color_maps/diamond_pickaxe.json) | [diamond_pickaxe.pdf](paint_by_numbers/diamond_pickaxe.pdf) |
+| Crafting Table | ![Crafting Table](svgs/crafting_table_top.svg) | [crafting_table_top.json](color_maps/crafting_table_top.json) | [crafting_table_top.pdf](paint_by_numbers/crafting_table_top.pdf) |
 | Oak Log | ![Oak Log](svgs/oak_log.svg) | [oak_log.json](color_maps/oak_log.json) | [oak_log.pdf](paint_by_numbers/oak_log.pdf) |
 | Stone | ![Stone](svgs/stone.svg) | [stone.json](color_maps/stone.json) | [stone.pdf](paint_by_numbers/stone.pdf) |
 | Diamond | ![Diamond](svgs/diamond.svg) | [diamond.json](color_maps/diamond.json) | [diamond.pdf](paint_by_numbers/diamond.pdf) |
@@ -17,13 +19,11 @@ You can view an interactive preview of these textures on the [GitHub Pages site]
 | Dirt | ![Dirt](svgs/dirt.svg) | [dirt.json](color_maps/dirt.json) | [dirt.pdf](paint_by_numbers/dirt.pdf) |
 | Cobblestone | ![Cobblestone](svgs/cobblestone.svg) | [cobblestone.json](color_maps/cobblestone.json) | [cobblestone.pdf](paint_by_numbers/cobblestone.pdf) |
 | Oak Planks | ![Oak Planks](svgs/oak_planks.svg) | [oak_planks.json](color_maps/oak_planks.json) | [oak_planks.pdf](paint_by_numbers/oak_planks.pdf) |
-| Crafting Table | ![Crafting Table](svgs/crafting_table_top.svg) | [crafting_table_top.json](color_maps/crafting_table_top.json) | [crafting_table_top.pdf](paint_by_numbers/crafting_table_top.pdf) |
 | Iron Ingot | ![Iron Ingot](svgs/iron_ingot.svg) | [iron_ingot.json](color_maps/iron_ingot.json) | [iron_ingot.pdf](paint_by_numbers/iron_ingot.pdf) |
 | Gold Ingot | ![Gold Ingot](svgs/gold_ingot.svg) | [gold_ingot.json](color_maps/gold_ingot.json) | [gold_ingot.pdf](paint_by_numbers/gold_ingot.pdf) |
 | Apple | ![Apple](svgs/apple.svg) | [apple.json](color_maps/apple.json) | [apple.pdf](paint_by_numbers/apple.pdf) |
 | Bread | ![Bread](svgs/bread.svg) | [bread.json](color_maps/bread.json) | [bread.pdf](paint_by_numbers/bread.pdf) |
 | Iron Sword | ![Iron Sword](svgs/iron_sword.svg) | [iron_sword.json](color_maps/iron_sword.json) | [iron_sword.pdf](paint_by_numbers/iron_sword.pdf) |
-| Diamond Pickaxe | ![Diamond Pickaxe](svgs/diamond_pickaxe.svg) | [diamond_pickaxe.json](color_maps/diamond_pickaxe.json) | [diamond_pickaxe.pdf](paint_by_numbers/diamond_pickaxe.pdf) |
 | Torch | ![Torch](svgs/torch.svg) | [torch.json](color_maps/torch.json) | [torch.pdf](paint_by_numbers/torch.pdf) |
 | Water Bucket | ![Water Bucket](svgs/water_bucket.svg) | [water_bucket.json](color_maps/water_bucket.json) | [water_bucket.pdf](paint_by_numbers/water_bucket.pdf) |
 | Glass | ![Glass](svgs/glass.svg) | [glass.json](color_maps/glass.json) | [glass.pdf](paint_by_numbers/glass.pdf) |

--- a/generate_index.py
+++ b/generate_index.py
@@ -28,7 +28,27 @@ def get_wiki_link(base_name):
 
 def main():
     svg_dir = 'svgs'
-    svg_files = sorted([f for f in os.listdir(svg_dir) if f.endswith('.svg')])
+
+    # Ordered list of textures
+    texture_order = [
+        'tnt_side', 'diamond_pickaxe', 'crafting_table_top', 'oak_log', 'stone',
+        'diamond', 'netherite_ingot', 'grass_block_top', 'dirt', 'cobblestone',
+        'oak_planks', 'iron_ingot', 'gold_ingot', 'apple', 'bread',
+        'iron_sword', 'torch', 'water_bucket', 'glass', 'matrix'
+    ]
+
+    # Filter and sort according to texture_order
+    svg_files = []
+    for base_name in texture_order:
+        filename = base_name + '.svg'
+        if os.path.exists(os.path.join(svg_dir, filename)):
+            svg_files.append(filename)
+
+    # Add any remaining svg files that were not in the texture_order
+    all_svgs = sorted([f for f in os.listdir(svg_dir) if f.endswith('.svg')])
+    for f in all_svgs:
+        if f not in svg_files:
+            svg_files.append(f)
 
     html_content = """
 <!DOCTYPE html>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,97 @@
     <div class="grid">
 
         <div class="card">
+            <img src="svgs/tnt_side.svg" alt="TNT">
+            <div class="name">TNT</div>
+            <a href="https://minecraft.wiki/w/TNT" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/tnt_side.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/diamond_pickaxe.svg" alt="Diamond Pickaxe">
+            <div class="name">Diamond Pickaxe</div>
+            <a href="https://minecraft.wiki/w/Diamond_Pickaxe" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/diamond_pickaxe.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/crafting_table_top.svg" alt="Crafting Table">
+            <div class="name">Crafting Table</div>
+            <a href="https://minecraft.wiki/w/Crafting_Table" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/crafting_table_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/oak_log.svg" alt="Oak Log">
+            <div class="name">Oak Log</div>
+            <a href="https://minecraft.wiki/w/Oak_Log" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/oak_log.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/stone.svg" alt="Stone">
+            <div class="name">Stone</div>
+            <a href="https://minecraft.wiki/w/Stone" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/stone.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/diamond.svg" alt="Diamond">
+            <div class="name">Diamond</div>
+            <a href="https://minecraft.wiki/w/Diamond" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/diamond.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/netherite_ingot.svg" alt="Netherite Ingot">
+            <div class="name">Netherite Ingot</div>
+            <a href="https://minecraft.wiki/w/Netherite_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/netherite_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/grass_block_top.svg" alt="Grass Block">
+            <div class="name">Grass Block</div>
+            <a href="https://minecraft.wiki/w/Grass_Block" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/grass_block_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/dirt.svg" alt="Dirt">
+            <div class="name">Dirt</div>
+            <a href="https://minecraft.wiki/w/Dirt" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/dirt.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/cobblestone.svg" alt="Cobblestone">
+            <div class="name">Cobblestone</div>
+            <a href="https://minecraft.wiki/w/Cobblestone" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/cobblestone.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/oak_planks.svg" alt="Oak Planks">
+            <div class="name">Oak Planks</div>
+            <a href="https://minecraft.wiki/w/Oak_Planks" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/oak_planks.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/iron_ingot.svg" alt="Iron Ingot">
+            <div class="name">Iron Ingot</div>
+            <a href="https://minecraft.wiki/w/Iron_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/iron_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/gold_ingot.svg" alt="Gold Ingot">
+            <div class="name">Gold Ingot</div>
+            <a href="https://minecraft.wiki/w/Gold_Ingot" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/gold_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
             <img src="svgs/apple.svg" alt="Apple">
             <div class="name">Apple</div>
             <a href="https://minecraft.wiki/w/Apple" target="_blank">View on Minecraft Wiki</a>
@@ -80,115 +171,10 @@
         </div>
 
         <div class="card">
-            <img src="svgs/cobblestone.svg" alt="Cobblestone">
-            <div class="name">Cobblestone</div>
-            <a href="https://minecraft.wiki/w/Cobblestone" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/cobblestone.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/crafting_table_top.svg" alt="Crafting Table">
-            <div class="name">Crafting Table</div>
-            <a href="https://minecraft.wiki/w/Crafting_Table" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/crafting_table_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/diamond.svg" alt="Diamond">
-            <div class="name">Diamond</div>
-            <a href="https://minecraft.wiki/w/Diamond" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/diamond.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/diamond_pickaxe.svg" alt="Diamond Pickaxe">
-            <div class="name">Diamond Pickaxe</div>
-            <a href="https://minecraft.wiki/w/Diamond_Pickaxe" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/diamond_pickaxe.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/dirt.svg" alt="Dirt">
-            <div class="name">Dirt</div>
-            <a href="https://minecraft.wiki/w/Dirt" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/dirt.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/glass.svg" alt="Glass">
-            <div class="name">Glass</div>
-            <a href="https://minecraft.wiki/w/Glass" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/glass.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/gold_ingot.svg" alt="Gold Ingot">
-            <div class="name">Gold Ingot</div>
-            <a href="https://minecraft.wiki/w/Gold_Ingot" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/gold_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/grass_block_top.svg" alt="Grass Block">
-            <div class="name">Grass Block</div>
-            <a href="https://minecraft.wiki/w/Grass_Block" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/grass_block_top.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/iron_ingot.svg" alt="Iron Ingot">
-            <div class="name">Iron Ingot</div>
-            <a href="https://minecraft.wiki/w/Iron_Ingot" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/iron_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
             <img src="svgs/iron_sword.svg" alt="Iron Sword">
             <div class="name">Iron Sword</div>
             <a href="https://minecraft.wiki/w/Iron_Sword" target="_blank">View on Minecraft Wiki</a>
             <a href="paint_by_numbers/iron_sword.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/matrix.svg" alt="Matrix">
-            <div class="name">Matrix</div>
-            <a href="https://chatelao.github.io/minecraft-led-panel-and-cube/" target="_blank">View Project Homepage</a>
-            <a href="paint_by_numbers/matrix.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/netherite_ingot.svg" alt="Netherite Ingot">
-            <div class="name">Netherite Ingot</div>
-            <a href="https://minecraft.wiki/w/Netherite_Ingot" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/netherite_ingot.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/oak_log.svg" alt="Oak Log">
-            <div class="name">Oak Log</div>
-            <a href="https://minecraft.wiki/w/Oak_Log" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/oak_log.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/oak_planks.svg" alt="Oak Planks">
-            <div class="name">Oak Planks</div>
-            <a href="https://minecraft.wiki/w/Oak_Planks" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/oak_planks.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/stone.svg" alt="Stone">
-            <div class="name">Stone</div>
-            <a href="https://minecraft.wiki/w/Stone" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/stone.pdf" target="_blank">Download Paint by Numbers PDF</a>
-        </div>
-
-        <div class="card">
-            <img src="svgs/tnt_side.svg" alt="TNT">
-            <div class="name">TNT</div>
-            <a href="https://minecraft.wiki/w/TNT" target="_blank">View on Minecraft Wiki</a>
-            <a href="paint_by_numbers/tnt_side.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
         <div class="card">
@@ -203,6 +189,20 @@
             <div class="name">Water Bucket</div>
             <a href="https://minecraft.wiki/w/Water_Bucket" target="_blank">View on Minecraft Wiki</a>
             <a href="paint_by_numbers/water_bucket.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/glass.svg" alt="Glass">
+            <div class="name">Glass</div>
+            <a href="https://minecraft.wiki/w/Glass" target="_blank">View on Minecraft Wiki</a>
+            <a href="paint_by_numbers/glass.pdf" target="_blank">Download Paint by Numbers PDF</a>
+        </div>
+
+        <div class="card">
+            <img src="svgs/matrix.svg" alt="Matrix">
+            <div class="name">Matrix</div>
+            <a href="https://chatelao.github.io/minecraft-led-panel-and-cube/" target="_blank">View Project Homepage</a>
+            <a href="paint_by_numbers/matrix.pdf" target="_blank">Download Paint by Numbers PDF</a>
         </div>
 
     </div>


### PR DESCRIPTION
The user requested a specific order for the Minecraft texture tiles: TNT, Diamond Pickaxe, Crafting Table, followed by the others.

I have updated the 'generate_index.py' script to include an explicit list of textures in the desired order. Any additional textures found in the 'svgs/' directory that are not in the explicit list will be appended at the end. I then ran this script to update 'index.html'.

I also manually updated the 'README.md' file's texture table to ensure it remains consistent with the website's layout.

Visual verification via Playwright confirmed the new order in the generated HTML.

Fixes #29

---
*PR created automatically by Jules for task [13949016690858627459](https://jules.google.com/task/13949016690858627459) started by @chatelao*